### PR TITLE
Should use deterministic K instead of random K in message

### DIFF
--- a/lib/message/message.js
+++ b/lib/message/message.js
@@ -47,7 +47,7 @@ Message.prototype._sign = function _sign (privateKey) {
   ecdsa.hashbuf = hash
   ecdsa.privkey = privateKey
   ecdsa.pubkey = privateKey.toPublicKey()
-  ecdsa.signRandomK()
+  ecdsa.sign()
   ecdsa.calci()
   return ecdsa.sig
 }


### PR DESCRIPTION
As is described in RFC6979 (https://tools.ietf.org/html/rfc6979#section-3.2), and is already implemented in bsv.crypto.ECDSA.

Besides, actually it's already easy to sign with bsv.

var priv = bsv.PrivateKey()
var message = "some message"
var hashbuf = bsv.crypto.Hash.sha256(Buffer.from(message))
var sig=bsv.crypto.ECDSA.sign(hashbuf,priv)
var sigstr = sig.toDER().toString('base64')

var sig=bsv.crypto.Signature.fromDER(Buffer.from(sigstr,'base64'))
bsv.crypto.ECDSA.verify(hashbuf,sig,priv.publicKey)