### PR TITLE
private key: change api

### DIFF
--- a/lib/ecies/electrum-ecies.js
+++ b/lib/ecies/electrum-ecies.js
@@ -68,7 +68,7 @@ var ECIES = function ECIES (opts, algorithm = 'BIE1') {
 ECIES.prototype.privateKey = function (privateKey) {
   $.checkArgument(PrivateKey.isValid(privateKey), 'no private key provided')
 
-  this._privateKey = PrivateKey(privateKey.toString()) || null
+  this._privateKey = PrivateKey(privateKey.toHex()) || null
   this.opts.ephemeralKey = false
 
   return this

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -243,7 +243,7 @@ PrivateKey.fromString = PrivateKey.fromWIF = function (str) {
  *
  * @param {Object} obj - The output from privateKey.toObject()
  */
-PrivateKey.fromObject = PrivateKey.fromJSON  = function (obj) {
+PrivateKey.fromObject = PrivateKey.fromJSON = function (obj) {
   $.checkArgument(_.isObject(obj), 'First argument is expected to be an object.')
   return new PrivateKey(obj)
 }
@@ -340,7 +340,7 @@ PrivateKey.prototype.toBuffer = function () {
   return this.bn.toBuffer({ size: 32 })
 }
 
-PrivateKey.prototype.toHex = function() {
+PrivateKey.prototype.toHex = function () {
   return this.toBuffer().toString('hex')
 }
 

--- a/lib/privatekey.js
+++ b/lib/privatekey.js
@@ -12,7 +12,7 @@ var Random = require('./crypto/random')
 var $ = require('./util/preconditions')
 
 /**
- * Instantiate a PrivateKey from a BN, Buffer and WIF.
+ * Instantiate a PrivateKey from a BN, Buffer or WIF string.
  *
  * @example
  * ```javascript
@@ -197,12 +197,16 @@ PrivateKey._transformWIF = function (str, network) {
 /**
  * Instantiate a PrivateKey from a Buffer with the DER or WIF representation
  *
- * @param {Buffer} arg
+ * @param {Buffer} buf
  * @param {Network} network
  * @return {PrivateKey}
  */
-PrivateKey.fromBuffer = function (arg, network) {
-  return new PrivateKey(arg, network)
+PrivateKey.fromBuffer = function (buf, network) {
+  return new PrivateKey(buf, network)
+}
+
+PrivateKey.fromHex = function (hex, network) {
+  return PrivateKey.fromBuffer(Buffer.from(hex, 'hex'), network)
 }
 
 /**
@@ -239,7 +243,7 @@ PrivateKey.fromString = PrivateKey.fromWIF = function (str) {
  *
  * @param {Object} obj - The output from privateKey.toObject()
  */
-PrivateKey.fromObject = function (obj) {
+PrivateKey.fromObject = PrivateKey.fromJSON  = function (obj) {
   $.checkArgument(_.isObject(obj), 'First argument is expected to be an object.')
   return new PrivateKey(obj)
 }
@@ -288,12 +292,12 @@ PrivateKey.isValid = function (data, network) {
 }
 
 /**
- * Will output the PrivateKey encoded as hex string
+ * Will output the PrivateKey in WIF
  *
  * @returns {string}
  */
 PrivateKey.prototype.toString = function () {
-  return this.toBuffer().toString('hex')
+  return this.toWIF()
 }
 
 /**
@@ -333,20 +337,11 @@ PrivateKey.prototype.toBigNumber = function () {
  * @returns {Buffer} A buffer of the private key
  */
 PrivateKey.prototype.toBuffer = function () {
-  // TODO: use `return this.bn.toBuffer({ size: 32 })` in v1.0.0
-  return this.bn.toBuffer()
+  return this.bn.toBuffer({ size: 32 })
 }
 
-/**
- * WARNING: This method will not be officially supported until v1.0.0.
- *
- *
- * Will return the private key as a BN buffer without leading zero padding
- *
- * @returns {Buffer} A buffer of the private key
- */
-PrivateKey.prototype.toBufferNoPadding = function () {
-  return this.bn.toBuffer()
+PrivateKey.prototype.toHex = function() {
+  return this.toBuffer().toString('hex')
 }
 
 /**
@@ -391,7 +386,7 @@ PrivateKey.prototype.toObject = PrivateKey.prototype.toJSON = function toObject 
  */
 PrivateKey.prototype.inspect = function () {
   var uncompressed = !this.compressed ? ', uncompressed' : ''
-  return '<PrivateKey: ' + this.toString() + ', network: ' + this.network + uncompressed + '>'
+  return '<PrivateKey: ' + this.toHex() + ', network: ' + this.network + uncompressed + '>'
 }
 
 module.exports = PrivateKey

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -233,7 +233,7 @@ describe('BIP32 compliance', function () {
       chainCode: chainCodeBuffer
     })
     var derived = key.deriveChild("m/44'/0'/0'/0/0'")
-    derived.privateKey.toString().should.equal('3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb')
+    derived.privateKey.toHex().should.equal('3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb')
   })
 
   it('should NOT use full 32 bytes for private key data that is hashed with nonCompliant flag', function () {
@@ -249,7 +249,7 @@ describe('BIP32 compliance', function () {
       chainCode: chainCodeBuffer
     })
     var derived = key.deriveNonCompliantChild("m/44'/0'/0'/0/0'")
-    derived.privateKey.toString().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836')
+    derived.privateKey.toHex().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836')
   })
 
   it('should NOT use full 32 bytes for private key data that is hashed with the nonCompliant derive method', function () {
@@ -265,7 +265,7 @@ describe('BIP32 compliance', function () {
       chainCode: chainCodeBuffer
     })
     var derived = key.derive("m/44'/0'/0'/0/0'")
-    derived.privateKey.toString().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836')
+    derived.privateKey.toHex().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836')
   })
 
   describe('edge cases', function () {
@@ -299,7 +299,7 @@ describe('BIP32 compliance', function () {
         chainCode: chainCodeBuffer
       })
       var derived = key.derive("m/44'")
-      derived.privateKey.toString().should.equal('b15bce3608d607ee3a49069197732c656bca942ee59f3e29b4d56914c1de6825')
+      derived.privateKey.toHex().should.equal('b15bce3608d607ee3a49069197732c656bca942ee59f3e29b4d56914c1de6825')
       bsv.PrivateKey.isValid.callCount.should.equal(2)
     })
     it('will handle edge case that a derive public key is invalid', function () {

--- a/test/privatekey.js
+++ b/test/privatekey.js
@@ -208,6 +208,16 @@ describe('PrivateKey', function () {
       JSON.stringify(key).should.equal(json)
     })
 
+    it('should input/output json', function () {
+      var json = JSON.stringify({
+        bn: '96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a',
+        compressed: false,
+        network: 'livenet'
+      })
+      var key = PrivateKey.fromJSON(JSON.parse(json))
+      JSON.stringify(key).should.equal(json)
+    })
+
     it('input json should correctly initialize network field', function () {
       ['livenet', 'testnet', 'mainnet'].forEach(function (net) {
         var pk = PrivateKey.fromObject({
@@ -228,6 +238,12 @@ describe('PrivateKey', function () {
     it('also accepts an object as argument', function () {
       expect(function () {
         return PrivateKey.fromObject(new PrivateKey().toObject())
+      }).to.not.throw()
+    })
+
+    it('also accepts an object as argument', function () {
+      expect(function () {
+        return PrivateKey.fromObject(new PrivateKey().toJSON())
       }).to.not.throw()
     })
   })
@@ -315,38 +331,15 @@ describe('PrivateKey', function () {
   describe('buffer serialization', function () {
     it('returns an expected value when creating a PrivateKey from a buffer', function () {
       var privkey = new PrivateKey(BN.fromBuffer(buf), 'livenet')
-      privkey.toString().should.equal(buf.toString('hex'))
+      privkey.toHex().should.equal(buf.toString('hex'))
     })
 
     it('roundtrips correctly when using toBuffer/fromBuffer', function () {
       var privkey = new PrivateKey(BN.fromBuffer(buf))
       var toBuffer = new PrivateKey(privkey.toBuffer())
       var fromBuffer = PrivateKey.fromBuffer(toBuffer.toBuffer())
-      fromBuffer.toString().should.equal(privkey.toString())
+      fromBuffer.toHex().should.equal(privkey.toHex())
     })
-
-    it('will output a 31 byte buffer', function () {
-      var bn = BN.fromBuffer(Buffer.from('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'))
-      var privkey = new PrivateKey(bn)
-      var buffer = privkey.toBufferNoPadding()
-      buffer.length.should.equal(31)
-    })
-
-    // TODO: enable for v1.0.0 when toBuffer is changed to always be 32 bytes long
-    // it('will output a 32 byte buffer', function() {
-    //   var bn = BN.fromBuffer(Buffer.from('9b5a0e8fee1835e21170ce1431f9b6f19b487e67748ed70d8a4462bc031915', 'hex'));
-    //   var privkey = new PrivateKey(bn);
-    //   var buffer = privkey.toBuffer();
-    //   buffer.length.should.equal(32);
-    // });
-
-    // TODO: enable for v1.0.0 when toBuffer is changed to always be 32 bytes long
-    // it('should return buffer with length equal 32', function() {
-    //   var bn = BN.fromBuffer(buf.slice(0, 31));
-    //   var privkey = new PrivateKey(bn, 'livenet');
-    //   var expected = Buffer.concat([ Buffer.from([0]), buf.slice(0, 31) ]);
-    //   privkey.toBuffer().toString('hex').should.equal(expected.toString('hex'));
-    // });
   })
 
   describe('#toBigNumber', function () {
@@ -391,7 +384,7 @@ describe('PrivateKey', function () {
   describe('#toString', function () {
     it('should parse this uncompressed livenet address correctly', function () {
       var privkey = PrivateKey.fromString(wifLivenetUncompressed)
-      privkey.toString().should.equal('96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a')
+      privkey.toHex().should.equal('96c132224121b509b7d0a16245e957d9192609c5637c6228311287b1be21627a')
     })
   })
 


### PR DESCRIPTION
toString and fromString should be symmetric. toString now outputs a WIF,
which is what is input into fromString. i have added to/fromHex if you
want the hex form. i have also made minor documentation updates.

i also removed the outdated form of returning a private key that did something other than restrict the size to 32 bytes. this was a bitcore bug that is no longer relevant.