### PR TITLE
there was a bug in derive()

### DIFF
--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -154,8 +154,8 @@ HDPrivateKey._getDerivationIndexes = function (path) {
  * @param {string|number} arg
  * @param {boolean?} hardened
  */
-HDPrivateKey.prototype.derive = function (arg, hardened) {
-  return this.deriveNonCompliantChild(arg, hardened)
+HDPrivateKey.prototype.derive = function () {
+  throw new Error('derive has been deprecated. use deriveChild or, for the old way, deriveNonCompliantChild.')
 }
 
 /**

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -114,8 +114,8 @@ HDPublicKey.isValidPath = function (arg) {
  *
  * @param {string|number} arg
  */
-HDPublicKey.prototype.derive = function (arg, hardened) {
-  return this.deriveChild(arg, hardened)
+HDPublicKey.prototype.derive = function () {
+  throw new Error('derive has been deprecated. use deriveChild or, for the old way, deriveNonCompliantChild.')
 }
 
 /**

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -79,69 +79,69 @@ describe('BIP32 compliance', function () {
   })
 
   it("should get m/0' ext. private key from test vector 1", function () {
-    var privateKey = new HDPrivateKey(vector1MPrivate).derive("m/0'")
+    var privateKey = new HDPrivateKey(vector1MPrivate).deriveChild("m/0'")
     privateKey.xprivkey.should.equal(vector1m0hprivate)
   })
 
   it("should get m/0' ext. public key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'")
       .xpubkey.should.equal(vector1m0hPublic)
   })
 
   it("should get m/0'/1 ext. private key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1")
       .xprivkey.should.equal(vector1m0h1private)
   })
 
   it("should get m/0'/1 ext. public key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1")
       .xpubkey.should.equal(vector1m0h1public)
   })
 
   it("should get m/0'/1 ext. public key from m/0' public key from test vector 1", function () {
-    var derivedPublic = HDPrivateKey(vector1MPrivate).derive("m/0'").hdPublicKey.derive('m/1')
+    var derivedPublic = HDPrivateKey(vector1MPrivate).deriveChild("m/0'").hdPublicKey.deriveChild('m/1')
     derivedPublic.xpubkey.should.equal(vector1m0h1public)
   })
 
   it("should get m/0'/1/2' ext. private key from test vector 1", function () {
     var privateKey = new HDPrivateKey(vector1MPrivate)
-    var derived = privateKey.derive("m/0'/1/2'")
+    var derived = privateKey.deriveChild("m/0'/1/2'")
     derived.xprivkey.should.equal(vector1m0h12hprivate)
   })
 
   it("should get m/0'/1/2' ext. public key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'")
       .xpubkey.should.equal(vector1m0h12hpublic)
   })
 
   it("should get m/0'/1/2'/2 ext. private key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'/2")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'/2")
       .xprivkey.should.equal(vector1m0h12h2private)
   })
 
   it("should get m/0'/1/2'/2 ext. public key from m/0'/1/2' public key from test vector 1", function () {
-    var derived = HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'").hdPublicKey
-    derived.derive('m/2').xpubkey.should.equal(vector1m0h12h2public)
+    var derived = HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'").hdPublicKey
+    derived.deriveChild('m/2').xpubkey.should.equal(vector1m0h12h2public)
   })
 
   it("should get m/0'/1/2h/2 ext. public key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'/2")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'/2")
       .xpubkey.should.equal(vector1m0h12h2public)
   })
 
   it("should get m/0'/1/2h/2/1000000000 ext. private key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'/2/1000000000")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'/2/1000000000")
       .xprivkey.should.equal(vector1m0h12h21000000000private)
   })
 
   it("should get m/0'/1/2h/2/1000000000 ext. public key from test vector 1", function () {
-    HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'/2/1000000000")
+    HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'/2/1000000000")
       .xpubkey.should.equal(vector1m0h12h21000000000public)
   })
 
   it("should get m/0'/1/2'/2/1000000000 ext. public key from m/0'/1/2'/2 public key from test vector 1", function () {
-    var derived = HDPrivateKey(vector1MPrivate).derive("m/0'/1/2'/2").hdPublicKey
-    derived.derive('m/1000000000').xpubkey.should.equal(vector1m0h12h21000000000public)
+    var derived = HDPrivateKey(vector1MPrivate).deriveChild("m/0'/1/2'/2").hdPublicKey
+    derived.deriveChild('m/1000000000').xpubkey.should.equal(vector1m0h12h21000000000public)
   })
 
   it('should initialize test vector 2 from the extended public key', function () {
@@ -157,66 +157,66 @@ describe('BIP32 compliance', function () {
   })
 
   it('should get m/0 ext. private key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive(0).xprivkey.should.equal(vector2m0private)
+    HDPrivateKey(vector2mprivate).deriveChild(0).xprivkey.should.equal(vector2m0private)
   })
 
   it('should get m/0 ext. public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive(0).xpubkey.should.equal(vector2m0public)
+    HDPrivateKey(vector2mprivate).deriveChild(0).xpubkey.should.equal(vector2m0public)
   })
 
   it('should get m/0 ext. public key from m public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).hdPublicKey.derive(0).xpubkey.should.equal(vector2m0public)
+    HDPrivateKey(vector2mprivate).hdPublicKey.deriveChild(0).xpubkey.should.equal(vector2m0public)
   })
 
   it('should get m/0/2147483647h ext. private key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'")
       .xprivkey.should.equal(vector2m02147483647hprivate)
   })
 
   it('should get m/0/2147483647h ext. public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'")
       .xpubkey.should.equal(vector2m02147483647hpublic)
   })
 
   it('should get m/0/2147483647h/1 ext. private key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1")
       .xprivkey.should.equal(vector2m02147483647h1private)
   })
 
   it('should get m/0/2147483647h/1 ext. public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1")
       .xpubkey.should.equal(vector2m02147483647h1public)
   })
 
   it('should get m/0/2147483647h/1 ext. public key from m/0/2147483647h public key from test vector 2', function () {
-    var derived = HDPrivateKey(vector2mprivate).derive("m/0/2147483647'").hdPublicKey
-    derived.derive(1).xpubkey.should.equal(vector2m02147483647h1public)
+    var derived = HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'").hdPublicKey
+    derived.deriveChild(1).xpubkey.should.equal(vector2m02147483647h1public)
   })
 
   it('should get m/0/2147483647h/1/2147483646h ext. private key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1/2147483646'")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1/2147483646'")
       .xprivkey.should.equal(vector2m02147483647h12147483646hprivate)
   })
 
   it('should get m/0/2147483647h/1/2147483646h ext. public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1/2147483646'")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1/2147483646'")
       .xpubkey.should.equal(vector2m02147483647h12147483646hpublic)
   })
 
   it('should get m/0/2147483647h/1/2147483646h/2 ext. private key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1/2147483646'/2")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1/2147483646'/2")
       .xprivkey.should.equal(vector2m02147483647h12147483646h2private)
   })
 
   it('should get m/0/2147483647h/1/2147483646h/2 ext. public key from test vector 2', function () {
-    HDPrivateKey(vector2mprivate).derive("m/0/2147483647'/1/2147483646'/2")
+    HDPrivateKey(vector2mprivate).deriveChild("m/0/2147483647'/1/2147483646'/2")
       .xpubkey.should.equal(vector2m02147483647h12147483646h2public)
   })
 
   it('should get m/0/2147483647h/1/2147483646h/2 ext. public key from m/0/2147483647h/2147483646h public key from test vector 2', function () {
     var derivedPublic = HDPrivateKey(vector2mprivate)
-      .derive("m/0/2147483647'/1/2147483646'").hdPublicKey
-    derivedPublic.derive('m/2')
+      .deriveChild("m/0/2147483647'/1/2147483646'").hdPublicKey
+    derivedPublic.deriveChild('m/2')
       .xpubkey.should.equal(vector2m02147483647h12147483646h2public)
   })
 
@@ -264,7 +264,7 @@ describe('BIP32 compliance', function () {
       privateKey: privateKeyBuffer,
       chainCode: chainCodeBuffer
     })
-    var derived = key.derive("m/44'/0'/0'/0/0'")
+    var derived = key.deriveNonCompliantChild("m/44'/0'/0'/0/0'")
     derived.privateKey.toHex().should.equal('4811a079bab267bfdca855b3bddff20231ff7044e648514fa099158472df2836')
   })
 
@@ -298,7 +298,7 @@ describe('BIP32 compliance', function () {
         privateKey: privateKeyBuffer,
         chainCode: chainCodeBuffer
       })
-      var derived = key.derive("m/44'")
+      var derived = key.deriveChild("m/44'")
       derived.privateKey.toHex().should.equal('b15bce3608d607ee3a49069197732c656bca942ee59f3e29b4d56914c1de6825')
       bsv.PrivateKey.isValid.callCount.should.equal(2)
     })
@@ -319,7 +319,7 @@ describe('BIP32 compliance', function () {
         throw new Error('Point cannot be equal to Infinity')
       }
       sandbox.spy(key, '_deriveWithNumber')
-      key.derive('m/44')
+      key.deriveChild('m/44')
       key._deriveWithNumber.callCount.should.equal(2)
       key.publicKey.toString().should.equal('029e58b241790284ef56502667b15157b3fc58c567f044ddc35653860f9455d099')
     })

--- a/test/hdprivatekey.js
+++ b/test/hdprivatekey.js
@@ -30,7 +30,7 @@ describe('HDPrivate key interface', function () {
   var expectDerivationFail = function (argument, error) {
     return expectFail(function () {
       var privateKey = new HDPrivateKey(xprivkey)
-      privateKey.derive(argument)
+      privateKey.deriveChild(argument)
     }, error)
   }
 
@@ -122,14 +122,14 @@ describe('HDPrivate key interface', function () {
 
   it('allows derivation of hardened keys by passing a very big number', function () {
     var privateKey = new HDPrivateKey(xprivkey)
-    var derivedByNumber = privateKey.derive(0x80000000)
-    var derivedByArgument = privateKey.derive(0, true)
+    var derivedByNumber = privateKey.deriveChild(0x80000000)
+    var derivedByArgument = privateKey.deriveChild(0, true)
     derivedByNumber.xprivkey.should.equal(derivedByArgument.xprivkey)
   })
 
   it('returns itself with \'m\' parameter', function () {
     var privateKey = new HDPrivateKey(xprivkey)
-    privateKey.should.equal(privateKey.derive('m'))
+    privateKey.should.equal(privateKey.deriveChild('m'))
   })
 
   it('returns InvalidArgument if invalid data is given to getSerializedError', function () {
@@ -202,8 +202,8 @@ describe('HDPrivate key interface', function () {
 
   it('shouldn\'t matter if derivations are made with strings or numbers', function () {
     var privateKey = new HDPrivateKey(xprivkey)
-    var derivedByString = privateKey.derive('m/0\'/1/2\'')
-    var derivedByNumber = privateKey.derive(0, true).derive(1).derive(2, true)
+    var derivedByString = privateKey.deriveChild('m/0\'/1/2\'')
+    var derivedByNumber = privateKey.deriveChild(0, true).deriveChild(1).deriveChild(2, true)
     derivedByNumber.xprivkey.should.equal(derivedByString.xprivkey)
   })
 

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -31,7 +31,7 @@ describe('HDPublicKey interface', function () {
   var expectDerivationFail = function (argument, error) {
     (function () {
       var pubkey = new HDPublicKey(xpubkey)
-      pubkey.derive(argument)
+      pubkey.deriveChild(argument)
     }).should.throw(error)
   }
 
@@ -209,15 +209,15 @@ describe('HDPublicKey interface', function () {
   describe('derivation', function () {
     it('derivation is the same whether deriving with number or string', function () {
       var pubkey = new HDPublicKey(xpubkey)
-      var derived1 = pubkey.derive(0).derive(1).derive(200000)
-      var derived2 = pubkey.derive('m/0/1/200000')
+      var derived1 = pubkey.deriveChild(0).deriveChild(1).deriveChild(200000)
+      var derived2 = pubkey.deriveChild('m/0/1/200000')
       derived1.xpubkey.should.equal(derived01200000)
       derived2.xpubkey.should.equal(derived01200000)
     })
 
     it('allows special parameters m, M', function () {
       var expectDerivationSuccess = function (argument) {
-        new HDPublicKey(xpubkey).derive(argument).xpubkey.should.equal(xpubkey)
+        new HDPublicKey(xpubkey).deriveChild(argument).xpubkey.should.equal(xpubkey)
       }
       expectDerivationSuccess('m')
       expectDerivationSuccess('M')
@@ -225,13 +225,13 @@ describe('HDPublicKey interface', function () {
 
     it('doesn\'t allow object arguments for derivation', function () {
       expectFail(function () {
-        return new HDPublicKey(xpubkey).derive({})
+        return new HDPublicKey(xpubkey).deriveChild({})
       }, hdErrors.InvalidDerivationArgument)
     })
 
     it('needs first argument for derivation', function () {
       expectFail(function () {
-        return new HDPublicKey(xpubkey).derive('s')
+        return new HDPublicKey(xpubkey).deriveChild('s')
       }, hdErrors.InvalidPath)
     })
 
@@ -245,13 +245,13 @@ describe('HDPublicKey interface', function () {
 
     it('can\'t derive hardened keys', function () {
       expectFail(function () {
-        return new HDPublicKey(xpubkey).derive(HDPublicKey.Hardened)
+        return new HDPublicKey(xpubkey).deriveChild(HDPublicKey.Hardened)
       }, hdErrors.InvalidIndexCantDeriveHardened)
     })
 
     it('can\'t derive hardened keys via second argument', function () {
       expectFail(function () {
-        return new HDPublicKey(xpubkey).derive(5, true)
+        return new HDPublicKey(xpubkey).deriveChild(5, true)
       }, hdErrors.InvalidIndexCantDeriveHardened)
     })
 


### PR DESCRIPTION
bitpay already deprecated it. no one should use it. if you are already
using it, that's OK, you can switch to deriveChildNonCompliant() which
is still in the source code. most people should use deriveChild().