### PR TITLE
Ecies fix

### DIFF
--- a/lib/ecies/electrum-ecies.js
+++ b/lib/ecies/electrum-ecies.js
@@ -57,7 +57,7 @@ AESCBC.decrypt = function (encbuf, keybuf, ivbuf) {
 var ECIES = function ECIES (opts, algorithm = 'BIE1') {
   if (algorithm !== 'BIE1') throw new errors.UnsupportAlgorithm(algorithm)
   if (!(this instanceof ECIES)) {
-    return new ECIES()
+    return new ECIES(opts, algorithm)
   }
   // use ephemeral key if privateKey is not set.
   this._privateKey = new bsv.PrivateKey()
@@ -78,30 +78,29 @@ ECIES.prototype.publicKey = function (publicKey) {
   $.checkArgument(PublicKey.isValid(publicKey), 'no public key provided')
 
   this._publicKey = PublicKey(publicKey.toString()) || null
+  if (this._publicKey != null) this.opts.fixedPublicKey = true
 
   return this
 }
 
-var cachedProperty = function (name, getter) {
+var defineProperty = function (name, getter) {
   var cachedName = '_' + name
   Object.defineProperty(ECIES.prototype, name, {
     configurable: false,
     enumerable: true,
     get: function () {
       var value = this[cachedName]
-      if (!value) {
-        value = this[cachedName] = getter.apply(this)
-      }
+      value = this[cachedName] = getter.apply(this)
       return value
     }
   })
 }
 
-cachedProperty('Rbuf', function () {
+defineProperty('Rbuf', function () {
   return this._privateKey.publicKey.toDER(true)
 })
 
-cachedProperty('ivkEkM', function () {
+defineProperty('ivkEkM', function () {
   var r = this._privateKey.bn
   var KB = this._publicKey.point
   var P = KB.mul(r)
@@ -110,15 +109,15 @@ cachedProperty('ivkEkM', function () {
   return Hash.sha512(Sbuf)
 })
 
-cachedProperty('iv', function () {
+defineProperty('iv', function () {
   return this.ivkEkM.slice(0, 16)
 })
 
-cachedProperty('kE', function () {
+defineProperty('kE', function () {
   return this.ivkEkM.slice(16, 32)
 })
 
-cachedProperty('kM', function () {
+defineProperty('kM', function () {
   return this.ivkEkM.slice(32, 64)
 })
 
@@ -153,7 +152,7 @@ ECIES.prototype.decrypt = function (encbuf) {
     var pub
     // BIE1 use compressed public key, length is always 33.
     pub = encbuf.slice(4, 37)
-    this._publicKey = PublicKey.fromDER(pub)
+    if (!this.opts.fixedPublicKey) this._publicKey = PublicKey.fromDER(pub)
     offset = 37
   }
 

--- a/lib/ecies/electrum-ecies.js
+++ b/lib/ecies/electrum-ecies.js
@@ -152,7 +152,8 @@ ECIES.prototype.decrypt = function (encbuf) {
     var pub
     // BIE1 use compressed public key, length is always 33.
     pub = encbuf.slice(4, 37)
-    if (!this.opts.fixedPublicKey) this._publicKey = PublicKey.fromDER(pub)
+    if (this.opts.fixedPublicKey) console.log('Notice: Overriding PublicKey in message. Consider use "noKey" option if you are not sending message to electrum and do not want to use ephemeral key')
+    else this._publicKey = PublicKey.fromDER(pub)
     offset = 37
   }
 

--- a/test/ecies/electrum-ecies.js
+++ b/test/ecies/electrum-ecies.js
@@ -60,6 +60,10 @@ describe('ECIES', function () {
     .privateKey(bobKey)
     .publicKey(aliceKey.publicKey)
 
+  var aliceReloaded = ECIES()
+    .privateKey(aliceKey)
+    .publicKey(bobKey.publicKey)
+
   var message = 'attack at dawn'
   var encrypted = 'QklFMQM55QTWSSsILaluEejwOXlrBs1IVcEB4kkqbxDz4Fap56+ajq0hzmnaQJXwUMZ/DUNgEx9i2TIhCA1mpBFIfxWZy+sH6H+sqqfX3sPHsGu0ug=='
   var encBuf = Buffer.from(encrypted, 'base64')
@@ -77,11 +81,31 @@ describe('ECIES', function () {
     decrypted.should.equal(message)
   })
 
+  it('correctly recovers a message', function () {
+    var decrypted = aliceReloaded
+      .decrypt(encBuf)
+      .toString()
+    decrypted.should.equal(message)
+  })
+
   it('retrieves senders publickey from the encypted buffer', function () {
     var bob2 = ECIES().privateKey(bobKey)
     var decrypted = bob2.decrypt(encBuf).toString()
     bob2._publicKey.toDER().should.deep.equal(aliceKey.publicKey.toDER())
     decrypted.should.equal(message)
+  })
+
+  var message1 = 'This is message from first sender'
+  var message2 = 'This is message from second sender'
+
+  it('decrypt messages from different senders', function () {
+    var sender1 = ECIES().publicKey(bobKey.publicKey)
+    var sender2 = ECIES().publicKey(bobKey.publicKey)
+    var bob2 = ECIES().privateKey(bobKey)
+    var decrypted1 = bob2.decrypt(sender1.encrypt(message1)).toString()
+    var decrypted2 = bob2.decrypt(sender2.encrypt(message2)).toString()
+    decrypted1.should.equal(message1)
+    decrypted2.should.equal(message2)
   })
 
   it('roundtrips', function () {


### PR DESCRIPTION
1. do not use cachedProperty now, as `iv` `kE` `kM` should not always be cached.
2. added `fixedPublicKey` mark, so receiver can override public key in message, for non-ephemeral-key sender to recover his message.
3. fixed options lost in new ECIES instance.