### PR TITLE
Remove lodash

### DIFF
--- a/lib/script/interpreter.js
+++ b/lib/script/interpreter.js
@@ -8,6 +8,7 @@ var BN = require('../crypto/bn')
 var Hash = require('../crypto/hash')
 var Signature = require('../crypto/signature')
 var PublicKey = require('../publickey')
+var cloneDeep = require('clone-deep')
 
 /**
  * Bitcoin transactions contain scripts. Each input has a script called the
@@ -522,7 +523,7 @@ Interpreter.prototype.evaluate = function () {
 Interpreter.prototype._callbackStep = function (thisStep) {
   if (typeof this.stepListener === 'function') {
     try {
-      this.stepListener(thisStep, _.cloneDeep(this.stack, true), _.cloneDeep(this.altstack, true))
+      this.stepListener(thisStep, cloneDeep(this.stack, true), cloneDeep(this.altstack, true))
     } catch (err) {
       console.log(`Error in Step callback:${err}`)
     }

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -340,15 +340,15 @@ Script.prototype.isPublicKeyHashIn = function () {
     var signatureBuf = this.chunks[0].buf
     var pubkeyBuf = this.chunks[1].buf
     if (signatureBuf &&
-        signatureBuf.length &&
-        signatureBuf[0] === 0x30 &&
-        pubkeyBuf &&
-        pubkeyBuf.length
+      signatureBuf.length &&
+      signatureBuf[0] === 0x30 &&
+      pubkeyBuf &&
+      pubkeyBuf.length
     ) {
       var version = pubkeyBuf[0]
       if ((version === 0x04 ||
-           version === 0x06 ||
-           version === 0x07) && pubkeyBuf.length === 65) {
+        version === 0x06 ||
+        version === 0x07) && pubkeyBuf.length === 65) {
         return true
       } else if ((version === 0x03 || version === 0x02) && pubkeyBuf.length === 33) {
         return true
@@ -373,15 +373,15 @@ Script.prototype.getPublicKeyHash = function () {
  */
 Script.prototype.isPublicKeyOut = function () {
   if (this.chunks.length === 2 &&
-      this.chunks[0].buf &&
-      this.chunks[0].buf.length &&
-      this.chunks[1].opcodenum === Opcode.OP_CHECKSIG) {
+    this.chunks[0].buf &&
+    this.chunks[0].buf.length &&
+    this.chunks[1].opcodenum === Opcode.OP_CHECKSIG) {
     var pubkeyBuf = this.chunks[0].buf
     var version = pubkeyBuf[0]
     var isVersion = false
     if ((version === 0x04 ||
-         version === 0x06 ||
-         version === 0x07) && pubkeyBuf.length === 65) {
+      version === 0x06 ||
+      version === 0x07) && pubkeyBuf.length === 65) {
       isVersion = true
     } else if ((version === 0x03 || version === 0x02) && pubkeyBuf.length === 33) {
       isVersion = true
@@ -400,8 +400,8 @@ Script.prototype.isPublicKeyIn = function () {
   if (this.chunks.length === 1) {
     var signatureBuf = this.chunks[0].buf
     if (signatureBuf &&
-        signatureBuf.length &&
-        signatureBuf[0] === 0x30) {
+      signatureBuf.length &&
+      signatureBuf[0] === 0x30) {
       return true
     }
   }
@@ -735,9 +735,7 @@ Script.buildMultisigOut = function (publicKeys, threshold, opts) {
   publicKeys = _.map(publicKeys, PublicKey)
   var sorted = publicKeys
   if (!opts.noSorting) {
-    sorted = _.sortBy(publicKeys, function (publicKey) {
-      return publicKey.toString('hex')
-    })
+    sorted = publicKeys.map(k => k.toString('hex')).sort().map(k => new PublicKey(k))
   }
   for (var i = 0; i < sorted.length; i++) {
     var publicKey = sorted[i]

--- a/lib/transaction/input/multisig.js
+++ b/lib/transaction/input/multisig.js
@@ -11,6 +11,7 @@ var Signature = require('../../crypto/signature')
 var Sighash = require('../sighash')
 var BufferUtil = require('../../util/buffer')
 var TransactionSignature = require('../signature')
+var PublicKey = require('../../publickey')
 
 /**
  * @constructor
@@ -21,7 +22,7 @@ function MultiSigInput (input, pubkeys, threshold, signatures) {
   pubkeys = pubkeys || input.publicKeys
   threshold = threshold || input.threshold
   signatures = signatures || input.signatures
-  this.publicKeys = _.sortBy(pubkeys, function (publicKey) { return publicKey.toString('hex') })
+  this.publicKeys = pubkeys.map(k => k.toString('hex')).sort().map(k => new PublicKey(k))
   $.checkState(Script.buildMultisigOut(this.publicKeys, threshold).equals(this.output.script),
     'Provided public keys don\'t match to the provided output script')
   this.publicKeyIndex = {}

--- a/lib/transaction/input/multisigscripthash.js
+++ b/lib/transaction/input/multisigscripthash.js
@@ -11,6 +11,7 @@ var Signature = require('../../crypto/signature')
 var Sighash = require('../sighash')
 var BufferUtil = require('../../util/buffer')
 var TransactionSignature = require('../signature')
+var PublicKey = require('../../publickey')
 
 /**
  * @constructor
@@ -21,7 +22,7 @@ function MultiSigScriptHashInput (input, pubkeys, threshold, signatures) {
   pubkeys = pubkeys || input.publicKeys
   threshold = threshold || input.threshold
   signatures = signatures || input.signatures
-  this.publicKeys = _.sortBy(pubkeys, function (publicKey) { return publicKey.toString('hex') })
+  this.publicKeys = pubkeys.map(k => k.toString('hex')).sort().map(k => new PublicKey(k))
   this.redeemScript = Script.buildMultisigOut(this.publicKeys, threshold)
   $.checkState(Script.buildScriptHashOut(this.redeemScript).equals(this.output.script),
     'Provided public keys don\'t hash to the provided output')

--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -950,7 +950,7 @@ Transaction.prototype.sort = function () {
 
 /**
  * Randomize this transaction's outputs ordering. The shuffling algorithm is a
- * version of the Fisher-Yates shuffle, provided by lodash's _.shuffle().
+ * version of the Fisher-Yates shuffle.
  *
  * @return {Transaction} this
  */
@@ -995,7 +995,7 @@ Transaction.prototype._newOutputOrder = function (newOutputs) {
 
   if (!_.isUndefined(this._changeIndex)) {
     var changeOutput = this.outputs[this._changeIndex]
-    this._changeIndex = _.findIndex(newOutputs, changeOutput)
+    this._changeIndex = newOutputs.indexOf(changeOutput)
   }
 
   this.outputs = newOutputs

--- a/lib/util/_.js
+++ b/lib/util/_.js
@@ -1,34 +1,44 @@
 'use strict'
 
-// Replace whole lodash with single functions
 var _ = {}
 
-_.isArray = require('lodash/isArray')
-_.isNumber = require('lodash/isNumber')
-_.isObject = require('lodash/isObject')
-_.isString = require('lodash/isString')
-_.isUndefined = require('lodash/isUndefined')
-_.isFunction = require('lodash/isFunction')
-_.isNull = require('lodash/isNull')
-_.isDate = require('lodash/isDate')
-_.extend = require('lodash/extend')
-_.noop = require('lodash/noop')
-_.every = require('lodash/every')
-_.map = require('lodash/map')
-_.includes = require('lodash/includes')
-_.each = require('lodash/each')
-_.clone = require('lodash/clone')
-_.pick = require('lodash/pick')
-_.values = require('lodash/values')
-_.cloneDeep = require('lodash/cloneDeep')
-_.sortBy = require('lodash/sortBy')
-_.filter = require('lodash/filter')
-_.reduce = require('lodash/reduce')
-_.without = require('lodash/without')
-_.shuffle = require('lodash/shuffle')
-_.difference = require('lodash/difference')
-_.findIndex = require('lodash/findIndex')
-_.some = require('lodash/some')
-_.range = require('lodash/range')
+_.isArray = t => Array.isArray(t)
+_.isNumber = t => typeof t === 'number'
+_.isObject = t => t && typeof t === 'object'
+_.isString = t => typeof t === 'string'
+_.isUndefined = t => typeof t === 'undefined'
+_.isFunction = t => typeof t === 'function'
+_.isNull = t => t === null
+_.isDate = t => t instanceof Date
+_.extend = (a, b) => Object.assign(a, b)
+_.noop = () => { }
+_.every = (a, f) => a.every(f || (t => t))
+_.map = (a, f) => Array.from(a).map(f || (t => t))
+_.includes = (a, e) => a.includes(e)
+_.each = (a, f) => a.forEach(f)
+_.clone = o => { const r = {}; Object.assign(r, o); return r }
+_.pick = (object, keys) => {
+  const obj = {}
+  keys.forEach(key => {
+    if (typeof object[key] !== 'undefined') { obj[key] = object[key] }
+  })
+  return obj
+}
+_.values = o => Object.values(o)
+_.filter = (a, f) => a.filter(f)
+_.reduce = (a, f, s) => a.reduce(f, s)
+_.without = (a, n) => a.filter(t => t !== n)
+_.shuffle = a => {
+  const result = a.slice(0)
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]]
+  }
+  return result
+}
+_.difference = (a, b) => a.filter(t => !b.includes(t))
+_.findIndex = (a, f) => a.findIndex(f)
+_.some = (a, f) => a.some(f)
+_.range = n => [...Array(n).keys()]
 
 module.exports = _

--- a/lib/util/_.js
+++ b/lib/util/_.js
@@ -16,7 +16,7 @@ _.every = (a, f) => a.every(f || (t => t))
 _.map = (a, f) => Array.from(a).map(f || (t => t))
 _.includes = (a, e) => a.includes(e)
 _.each = (a, f) => a.forEach(f)
-_.clone = o => { const r = {}; Object.assign(r, o); return r }
+_.clone = o => Object.assign({}, o)
 _.pick = (object, keys) => {
   const obj = {}
   keys.forEach(key => {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "bn.js": "=4.11.8",
     "bs58": "=4.0.1",
     "buffer-compare": "=1.1.1",
+    "clone-deep": "^4.0.1",
     "elliptic": "6.4.1",
     "hash.js": "^1.1.7",
     "inherits": "2.0.3",
-    "lodash": "=4.17.11",
     "mocha": "^5.2.0",
     "standard": "12.0.1",
     "unorm": "1.4.1",
@@ -55,6 +55,7 @@
   "devDependencies": {
     "brfs": "2.0.1",
     "chai": "4.2.0",
+    "lodash": "=4.17.11",
     "sinon": "7.2.3",
     "webpack-cli": "3.2.3"
   },


### PR DESCRIPTION
Vanilla JS replacements for lodash. This shaves ~30kb (~10%) off the main build.

Most of the replacements are straightforward ES5 calls. cloneDeep needed a library though and shuffle a modified Fisher-Yates implementation ([link](https://stackoverflow.com/questions/2450954/how-to-randomize-shuffle-a-javascript-array)). sortBy and pick also required some special work but nothing major. The main risk for this change is that we might break some code that depends on lodash specific implementations. Synced with Ryan offline and we think the benefit is worth it. bsv also has good test coverage.

In a follow-up PR, I'll inline the methods and remove `_.js`. That's going to be a more invasive change so wanted to get this in first. We'll also want to remove lodash from the tests.

**Testing**:
- [x] npm run test
- [x] npm run build