### PR TITLE
restore Satoshi Nakamoto's copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,6 +15,8 @@ Copyright (c) 2011 Stefan Thomas <justmoon@members.fsf.org>
 Parts of this software are based on BitcoinJ
 Copyright (c) 2011 Google Inc.
 
+Copyright (c) 2009 Satoshi Nakamoto
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
This code is partially based on Bitcoin Core. At some point in their
history, they removed Satoshi's copyright claim. That breaks the
license. In order to follow the license, we must have the original
copyright claim.

The original license is available here:

https://github.com/ryanxcharles/original-bitcoin/blob/92ee8d9a994391d148733da77e2bbc2f4acc43cd/src/license.txt