### PR TITLE
fix behavior of OP_RETURN outputs (buildDataOut)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Documentation is available on the [Money Button Documentation Page](https://docs
 Changelog
 ---------
 
+**0.28.0**
+* Add support for new OP_RETURN style: buildSafeDataOut and isSafeDataOut (and getData)
+
 **0.27.2**
 * Add support for Stress Test Network (STN).
 

--- a/docs/script.md
+++ b/docs/script.md
@@ -72,7 +72,7 @@ Data outputs are used to push data into the blockchain. Up to 40 bytes can be pu
 ```javascript
 var data = 'hello world!!!';
 var script = Script.buildDataOut(data);
-assert(script.toString() === 'OP_FALSE OP_RETURN 14 0x68656c6c6f20776f726c64212121'
+assert(script.toString() === 'OP_RETURN 14 0x68656c6c6f20776f726c64212121'
 ```
 
 ### Custom Scripts

--- a/docs/script.md
+++ b/docs/script.md
@@ -72,7 +72,7 @@ Data outputs are used to push data into the blockchain. Up to 40 bytes can be pu
 ```javascript
 var data = 'hello world!!!';
 var script = Script.buildDataOut(data);
-assert(script.toString() === 'OP_RETURN 14 0x68656c6c6f20776f726c64212121'
+assert(script.toString() === 'OP_FALSE OP_RETURN 14 0x68656c6c6f20776f726c64212121'
 ```
 
 ### Custom Scripts

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -477,7 +477,8 @@ Script.prototype.isMultisigIn = function () {
  */
 Script.prototype.isDataOut = function () {
   var step1 = this.chunks.length >= 1 &&
-    this.chunks[0].opcodenum === Opcode.OP_RETURN &&
+    this.chunks[0].opcodenum === Opcode.OP_FALSE &&
+    this.chunks[1].opcodenum === Opcode.OP_RETURN &&
     // this.toBuffer().length <= 223; // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
     this.toBuffer().length <= 100000 // Miners are mining big OP_RETURNs as of Jan 23, 2019
   if (!step1) return false
@@ -848,6 +849,7 @@ Script.buildDataOut = function (data, encoding) {
     datas = [data]
   }
   var s = new Script()
+  s.add(Opcode.OP_FALSE)
   s.add(Opcode.OP_RETURN)
   for (let data of datas) {
     $.checkArgument(_.isUndefined(data) || _.isString(data) || BufferUtil.isBuffer(data))

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -548,7 +548,7 @@ Script.types.SCRIPTHASH_IN = 'Spend from script hash'
 Script.types.MULTISIG_OUT = 'Pay to multisig'
 Script.types.MULTISIG_IN = 'Spend from multisig'
 Script.types.DATA_OUT = 'Data push'
-Script.types.PRUNABLE_DATA_OUT = 'Safe data push'
+Script.types.SAFE_DATA_OUT = 'Safe data push'
 
 Script.OP_RETURN_STANDARD_SIZE = 220
 
@@ -573,7 +573,7 @@ Script.outputIdentifiers.PUBKEYHASH_OUT = Script.prototype.isPublicKeyHashOut
 Script.outputIdentifiers.MULTISIG_OUT = Script.prototype.isMultisigOut
 Script.outputIdentifiers.SCRIPTHASH_OUT = Script.prototype.isScriptHashOut
 Script.outputIdentifiers.DATA_OUT = Script.prototype.isDataOut
-Script.outputIdentifiers.PRUNABLE_DATA_OUT = Script.prototype.isSafeDataOut
+Script.outputIdentifiers.SAFE_DATA_OUT = Script.prototype.isSafeDataOut
 
 /**
  * @returns {object} The Script type if it is a known form,

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -486,13 +486,31 @@ Script.prototype.isDataOut = function () {
   return script2.isPushOnly()
 }
 
+Script.prototype.isPrunableDataOut = function () {
+  if (this.chunks.length < 2) {
+    return false
+  }
+  if (this.chunks[0].opcodenum !== Opcode.OP_FALSE) {
+    return false
+  }
+  var chunks = this.chunks.slice(1)
+  var script2 = new Script({ chunks })
+  return script2.isDataOut()
+}
+
 /**
  * Retrieve the associated data for this script.
  * In the case of a pay to public key hash or P2SH, return the hash.
- * In the case of a standard OP_RETURN, return the data
+ * In the case of prunable OP_RETURN data, return an array of buffers
+ * In the case of a standard deprecated OP_RETURN, return the data
  * @returns {Buffer}
  */
 Script.prototype.getData = function () {
+  if (this.isPrunableDataOut()) {
+    var chunks = this.chunks.slice(2)
+    var buffers = chunks.map(chunk => chunk.buf)
+    return buffers
+  }
   if (this.isDataOut() || this.isScriptHashOut()) {
     if (_.isUndefined(this.chunks[1])) {
       return Buffer.alloc(0)
@@ -530,6 +548,7 @@ Script.types.SCRIPTHASH_IN = 'Spend from script hash'
 Script.types.MULTISIG_OUT = 'Pay to multisig'
 Script.types.MULTISIG_IN = 'Spend from multisig'
 Script.types.DATA_OUT = 'Data push'
+Script.types.PRUNABLE_DATA_OUT = 'Prunable data push'
 
 Script.OP_RETURN_STANDARD_SIZE = 220
 
@@ -554,6 +573,7 @@ Script.outputIdentifiers.PUBKEYHASH_OUT = Script.prototype.isPublicKeyHashOut
 Script.outputIdentifiers.MULTISIG_OUT = Script.prototype.isMultisigOut
 Script.outputIdentifiers.SCRIPTHASH_OUT = Script.prototype.isScriptHashOut
 Script.outputIdentifiers.DATA_OUT = Script.prototype.isDataOut
+Script.outputIdentifiers.PRUNABLE_DATA_OUT = Script.prototype.isPrunableDataOut
 
 /**
  * @returns {object} The Script type if it is a known form,
@@ -859,6 +879,19 @@ Script.buildDataOut = function (data, encoding) {
     }
   }
   return s
+}
+
+/**
+ * @returns {Script} a new OP_RETURN script with data
+ * @param {(string|Buffer|Array)} data - the data to embed in the output - it is a string, buffer, or array of strings or buffers
+ * @param {(string)} encoding - the type of encoding of the string(s)
+ */
+Script.buildPrunableDataOut = function (data, encoding) {
+  var s2 = Script.buildDataOut(data, encoding)
+  var s1 = new Script()
+  s1.add(Opcode.OP_FALSE)
+  s1.add(s2)
+  return s1
 }
 
 /**

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -486,7 +486,7 @@ Script.prototype.isDataOut = function () {
   return script2.isPushOnly()
 }
 
-Script.prototype.isPrunableDataOut = function () {
+Script.prototype.isSafeDataOut = function () {
   if (this.chunks.length < 2) {
     return false
   }
@@ -501,12 +501,12 @@ Script.prototype.isPrunableDataOut = function () {
 /**
  * Retrieve the associated data for this script.
  * In the case of a pay to public key hash or P2SH, return the hash.
- * In the case of prunable OP_RETURN data, return an array of buffers
+ * In the case of safe OP_RETURN data, return an array of buffers
  * In the case of a standard deprecated OP_RETURN, return the data
  * @returns {Buffer}
  */
 Script.prototype.getData = function () {
-  if (this.isPrunableDataOut()) {
+  if (this.isSafeDataOut()) {
     var chunks = this.chunks.slice(2)
     var buffers = chunks.map(chunk => chunk.buf)
     return buffers
@@ -548,7 +548,7 @@ Script.types.SCRIPTHASH_IN = 'Spend from script hash'
 Script.types.MULTISIG_OUT = 'Pay to multisig'
 Script.types.MULTISIG_IN = 'Spend from multisig'
 Script.types.DATA_OUT = 'Data push'
-Script.types.PRUNABLE_DATA_OUT = 'Prunable data push'
+Script.types.PRUNABLE_DATA_OUT = 'Safe data push'
 
 Script.OP_RETURN_STANDARD_SIZE = 220
 
@@ -573,7 +573,7 @@ Script.outputIdentifiers.PUBKEYHASH_OUT = Script.prototype.isPublicKeyHashOut
 Script.outputIdentifiers.MULTISIG_OUT = Script.prototype.isMultisigOut
 Script.outputIdentifiers.SCRIPTHASH_OUT = Script.prototype.isScriptHashOut
 Script.outputIdentifiers.DATA_OUT = Script.prototype.isDataOut
-Script.outputIdentifiers.PRUNABLE_DATA_OUT = Script.prototype.isPrunableDataOut
+Script.outputIdentifiers.PRUNABLE_DATA_OUT = Script.prototype.isSafeDataOut
 
 /**
  * @returns {object} The Script type if it is a known form,
@@ -886,7 +886,7 @@ Script.buildDataOut = function (data, encoding) {
  * @param {(string|Buffer|Array)} data - the data to embed in the output - it is a string, buffer, or array of strings or buffers
  * @param {(string)} encoding - the type of encoding of the string(s)
  */
-Script.buildPrunableDataOut = function (data, encoding) {
+Script.buildSafeDataOut = function (data, encoding) {
   var s2 = Script.buildDataOut(data, encoding)
   var s1 = new Script()
   s1.add(Opcode.OP_FALSE)

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -477,8 +477,7 @@ Script.prototype.isMultisigIn = function () {
  */
 Script.prototype.isDataOut = function () {
   var step1 = this.chunks.length >= 1 &&
-    this.chunks[0].opcodenum === Opcode.OP_FALSE &&
-    this.chunks[1].opcodenum === Opcode.OP_RETURN &&
+    this.chunks[0].opcodenum === Opcode.OP_RETURN &&
     // this.toBuffer().length <= 223; // 223 instead of 220 because (+1 for OP_RETURN, +2 for the pushdata opcodes)
     this.toBuffer().length <= 100000 // Miners are mining big OP_RETURNs as of Jan 23, 2019
   if (!step1) return false
@@ -849,7 +848,6 @@ Script.buildDataOut = function (data, encoding) {
     datas = [data]
   }
   var s = new Script()
-  s.add(Opcode.OP_FALSE)
   s.add(Opcode.OP_RETURN)
   for (let data of datas) {
     $.checkArgument(_.isUndefined(data) || _.isString(data) || BufferUtil.isBuffer(data))

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -348,55 +348,55 @@ describe('Script', function () {
     })
   })
 
-  describe('#isPrunableDataOut', function () {
+  describe('#isSafeDataOut', function () {
     it('should know this is a (blank) OP_RETURN script', function () {
-      Script('OP_FALSE OP_RETURN').isPrunableDataOut().should.equal(true)
+      Script('OP_FALSE OP_RETURN').isSafeDataOut().should.equal(true)
     })
 
     it('validates that this two part OP_RETURN is standard', function () {
-      Script.fromASM('OP_FALSE OP_RETURN 026d02 0568656c6c6f').isPrunableDataOut().should.equal(true)
+      Script.fromASM('OP_FALSE OP_RETURN 026d02 0568656c6c6f').isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 40-byte OP_RETURN is standard', function () {
       var buf = Buffer.alloc(40)
       buf.fill(0)
-      Script('OP_FALSE OP_RETURN 40 0x' + buf.toString('hex')).isPrunableDataOut().should.equal(true)
+      Script('OP_FALSE OP_RETURN 40 0x' + buf.toString('hex')).isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 80-byte OP_RETURN is standard', function () {
       var buf = Buffer.alloc(80)
       buf.fill(0)
-      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 80 0x' + buf.toString('hex')).isPrunableDataOut().should.equal(true)
+      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 80 0x' + buf.toString('hex')).isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 220-byte OP_RETURN is standard', function () {
       var buf = Buffer.alloc(220)
       buf.fill(0)
-      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 220 0x' + buf.toString('hex')).isPrunableDataOut().should.equal(true)
+      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 220 0x' + buf.toString('hex')).isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 40-byte long OP_CHECKMULTISIG is not standard op_return', function () {
       var buf = Buffer.alloc(40)
       buf.fill(0)
-      Script('OP_CHECKMULTISIG 40 0x' + buf.toString('hex')).isPrunableDataOut().should.equal(false)
+      Script('OP_CHECKMULTISIG 40 0x' + buf.toString('hex')).isSafeDataOut().should.equal(false)
     })
 
     it('validates that this 221-byte OP_RETURN is a valid standard OP_RETURN', function () {
       var buf = Buffer.alloc(221)
       buf.fill(0)
-      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 221 0x' + buf.toString('hex')).isPrunableDataOut().should.equal(true)
+      Script('OP_FALSE OP_RETURN OP_PUSHDATA1 221 0x' + buf.toString('hex')).isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 99994-byte OP_RETURN is a valid standard OP_RETURN', function () {
       var buf = Buffer.alloc(100000 - 6)
       buf.fill(0)
-      Script(`OP_FALSE OP_RETURN OP_PUSHDATA4 ${buf.length} 0x` + buf.toString('hex')).isPrunableDataOut().should.equal(true)
+      Script(`OP_FALSE OP_RETURN OP_PUSHDATA4 ${buf.length} 0x` + buf.toString('hex')).isSafeDataOut().should.equal(true)
     })
 
     it('validates that this 99995-byte OP_RETURN is not a valid standard OP_RETURN', function () {
       var buf = Buffer.alloc(100000 - 5)
       buf.fill(0)
-      Script(`OP_FALSE OP_RETURN OP_PUSHDATA4 ${buf.length} 0x` + buf.toString('hex')).isPrunableDataOut().should.equal(false)
+      Script(`OP_FALSE OP_RETURN OP_PUSHDATA4 ${buf.length} 0x` + buf.toString('hex')).isSafeDataOut().should.equal(false)
     })
   })
 
@@ -919,84 +919,84 @@ describe('Script', function () {
       s.isDataOut().should.equal(true)
     })
   })
-  describe('#buildPrunableDataOut', function () {
+  describe('#buildSafeDataOut', function () {
     it('should create script from no data', function () {
-      var s = Script.buildPrunableDataOut()
+      var s = Script.buildSafeDataOut()
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from empty data', function () {
       var data = Buffer.from('')
-      var s = Script.buildPrunableDataOut(data)
+      var s = Script.buildSafeDataOut(data)
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from some data', function () {
       var data = Buffer.from('bacacafe0102030405', 'hex')
-      var s = Script.buildPrunableDataOut(data)
+      var s = Script.buildSafeDataOut(data)
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 9 0xbacacafe0102030405')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from array of some data', function () {
       var data = Buffer.from('bacacafe0102030405', 'hex')
-      var s = Script.buildPrunableDataOut([data, data])
+      var s = Script.buildSafeDataOut([data, data])
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 9 0xbacacafe0102030405 9 0xbacacafe0102030405')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from array of some datas', function () {
       var data1 = Buffer.from('moneybutton.com')
       var data2 = Buffer.from('hello'.repeat(100))
-      var s = Script.buildPrunableDataOut([data1, data2])
+      var s = Script.buildSafeDataOut([data1, data2])
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 15 0x6d6f6e6579627574746f6e2e636f6d OP_PUSHDATA2 500 0x68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f68656c6c6f')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from array of lots of data', function () {
       var data1 = Buffer.from('moneybutton.com')
       var data2 = Buffer.from('00'.repeat(90000), 'hex')
-      var s = Script.buildPrunableDataOut([data1, data2])
+      var s = Script.buildSafeDataOut([data1, data2])
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 15 0x6d6f6e6579627574746f6e2e636f6d OP_PUSHDATA4 90000 0x' + '00'.repeat(90000))
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from string', function () {
       var data = 'hello world!!!'
-      var s = Script.buildPrunableDataOut(data)
+      var s = Script.buildSafeDataOut(data)
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 14 0x68656c6c6f20776f726c64212121')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from an array of strings', function () {
       var data = 'hello world!!!'
-      var s = Script.buildPrunableDataOut([data, data])
+      var s = Script.buildSafeDataOut([data, data])
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 14 0x68656c6c6f20776f726c64212121 14 0x68656c6c6f20776f726c64212121')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from a hex string', function () {
       var hexString = 'abcdef0123456789'
-      var s = Script.buildPrunableDataOut(hexString, 'hex')
+      var s = Script.buildSafeDataOut(hexString, 'hex')
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 8 0xabcdef0123456789')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from an array of a hex string', function () {
       var hexString = 'abcdef0123456789'
-      var s = Script.buildPrunableDataOut([hexString], 'hex')
+      var s = Script.buildSafeDataOut([hexString], 'hex')
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 8 0xabcdef0123456789')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
     it('should create script from an array of hex strings', function () {
       var hexString = 'abcdef0123456789'
-      var s = Script.buildPrunableDataOut([hexString, hexString], 'hex')
+      var s = Script.buildSafeDataOut([hexString, hexString], 'hex')
       should.exist(s)
       s.toString().should.equal('OP_0 OP_RETURN 8 0xabcdef0123456789 8 0xabcdef0123456789')
-      s.isPrunableDataOut().should.equal(true)
+      s.isSafeDataOut().should.equal(true)
     })
   })
   describe('#buildScriptHashOut', function () {
@@ -1099,7 +1099,7 @@ describe('Script', function () {
     it('for a old-style opreturn output', function () {
       expect(BufferUtil.equal(Script('OP_RETURN 1 0xFF').getData(), Buffer.from([255]))).to.equal(true)
     })
-    it('for a prunable opreturn output', function () {
+    it('for a safe opreturn output', function () {
       expect(BufferUtil.equal(Script('OP_FALSE OP_RETURN 1 0xFF').getData()[0], Buffer.from([255]))).to.equal(true)
     })
     it('fails if content is not recognized', function () {


### PR DESCRIPTION
The behavior of OP_RETURN is returning to the original. In order to create provably unspendable outputs, we need OP_FALSE OP_RETURN outputs.

See description here: https://bitcoinsv.io/2019/07/27/the-return-of-op_return-roadmap-to-genesis-part-4/

This PR changes the behavior of buildDataOut to always put a OP_FALSE at the start of the data output scripts.

This PR is intended to provoke a discussion about how best to go about changing this library. How best should we modify this library to support the proper style of prunable data outputs?