### PR TITLE
Moved mocha, standard and webpack dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "elliptic": "6.4.1",
     "hash.js": "^1.1.7",
     "inherits": "2.0.3",
-    "mocha": "^5.2.0",
-    "standard": "12.0.1",
-    "unorm": "1.4.1",
-    "webpack": "4.29.3"
+    "unorm": "1.4.1"
   },
   "devDependencies": {
+    "mocha": "^5.2.0",
+    "standard": "12.0.1",
+    "webpack": "4.29.3",
     "brfs": "2.0.1",
     "chai": "4.2.0",
     "lodash": "=4.17.11",


### PR DESCRIPTION
These packages are only used during development, and moving them to
devDependencies reduces the surface area for toolchain attacks