### PR TITLE
Remove unused function Random.getPseudoRandomBuffer()

### DIFF
--- a/lib/crypto/random.js
+++ b/lib/crypto/random.js
@@ -34,24 +34,4 @@ Random.getRandomBufferBrowser = function (size) {
   return buf
 }
 
-/* insecure random bytes, but it never fails */
-Random.getPseudoRandomBuffer = function (size) {
-  var b32 = 0x100000000
-  var b = Buffer.alloc(size)
-  var r
-
-  for (var i = 0; i <= size; i++) {
-    var j = Math.floor(i / 4)
-    var k = i - j * 4
-    if (k === 0) {
-      r = Math.random() * b32
-      b[i] = r & 0xff
-    } else {
-      b[i] = (r = r >>> 8) & 0xff
-    }
-  }
-
-  return b
-}
-
 module.exports = Random


### PR DESCRIPTION
When examining test coverage of random.js, it was evident that this
function was not used anywhere in the library.

This function should be removed as developers should not rely on it
to generate randomness.  Also it was already removed in an earlier
version of the library:

https://github.com/moneybutton/yours-bitcoin/commit/77171b74c3c4649f9e200286bc842a1d8dff8673