### PR TITLE
Remove lodash from unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "devDependencies": {
     "brfs": "2.0.1",
     "chai": "4.2.0",
-    "lodash": "=4.17.13",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
     "sinon": "7.2.3",

--- a/test/crypto/signature.js
+++ b/test/crypto/signature.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var _ = require('lodash')
+var _ = require('../../lib/util/_')
 var should = require('chai').should()
 var bsv = require('../..')
 var BN = bsv.crypto.BN

--- a/test/hdkeys.js
+++ b/test/hdkeys.js
@@ -10,7 +10,7 @@
 /* jshint maxstatements: 100 */
 /* jshint unused: false */
 
-var _ = require('lodash')
+var _ = require('../lib/util/_')
 require('chai').should()
 var expect = require('chai').expect
 var sinon = require('sinon')

--- a/test/hdprivatekey.js
+++ b/test/hdprivatekey.js
@@ -1,6 +1,6 @@
 'use strict'
 /* jshint unused: false */
-var _ = require('lodash')
+var _ = require('../lib/util/_')
 var assert = require('assert')
 var should = require('chai').should()
 var expect = require('chai').expect

--- a/test/hdprivatekey.js
+++ b/test/hdprivatekey.js
@@ -73,10 +73,10 @@ describe('HDPrivate key interface', function () {
   })
 
   it('builds a json keeping the structure and same members', function () {
-    assert(_.isEqual(
+    assert.deepStrictEqual(
       new HDPrivateKey(json).toJSON(),
       new HDPrivateKey(xprivkey).toJSON()
-    ))
+    )
   })
 
   describe('instantiation', function () {

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -1,7 +1,7 @@
 'use strict'
 
 /* jshint unused: false */
-var _ = require('lodash')
+var _ = require('../lib/util/_')
 var assert = require('assert')
 require('chai').should()
 var expect = require('chai').expect

--- a/test/hdpublickey.js
+++ b/test/hdpublickey.js
@@ -1,7 +1,6 @@
 'use strict'
 
 /* jshint unused: false */
-var _ = require('../lib/util/_')
 var assert = require('assert')
 require('chai').should()
 var expect = require('chai').expect
@@ -95,10 +94,10 @@ describe('HDPublicKey interface', function () {
     })
 
     it('can generate a json that has a particular structure', function () {
-      assert(_.isEqual(
+      assert.deepStrictEqual(
         new HDPublicKey(JSON.parse(json)).toJSON(),
         new HDPublicKey(xpubkey).toJSON()
-      ))
+      )
     })
 
     it('builds from a buffer object', function () {

--- a/test/opcode.js
+++ b/test/opcode.js
@@ -1,6 +1,5 @@
 'use strict'
 
-var _ = require('../lib/util/_')
 var chai = require('chai')
 var should = chai.should()
 var expect = chai.expect
@@ -85,7 +84,7 @@ describe('Opcode', function () {
 
   describe('@map', function () {
     it('should have a map containing 118 elements', function () {
-      _.size(Opcode.map).should.equal(118)
+      Object.keys(Opcode.map).length.should.equal(118)
     })
   })
 

--- a/test/opcode.js
+++ b/test/opcode.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var _ = require('lodash')
+var _ = require('../lib/util/_')
 var chai = require('chai')
 var should = chai.should()
 var expect = chai.expect

--- a/test/script/interpreter.js
+++ b/test/script/interpreter.js
@@ -9,7 +9,7 @@ var Script = bsv.Script
 var BN = bsv.crypto.BN
 var BufferWriter = bsv.encoding.BufferWriter
 var Opcode = bsv.Opcode
-var _ = require('lodash')
+var _ = require('../../lib/util/_')
 
 var scriptTests = require('../data/bitcoind/script_tests')
 var txValid = require('../data/bitcoind/tx_valid')

--- a/test/transaction/input/input.js
+++ b/test/transaction/input/input.js
@@ -2,7 +2,7 @@
 
 var should = require('chai').should()
 var expect = require('chai').expect
-var _ = require('lodash')
+var _ = require('../../../lib/util/_')
 
 var bsv = require('../../..')
 var errors = bsv.errors

--- a/test/transaction/input/multisig.js
+++ b/test/transaction/input/multisig.js
@@ -2,7 +2,7 @@
 /* jshint unused: false */
 
 var should = require('chai').should()
-var _ = require('lodash')
+var _ = require('../../../lib/util/_')
 
 var bsv = require('../../..')
 var Transaction = bsv.Transaction

--- a/test/transaction/input/multisigscripthash.js
+++ b/test/transaction/input/multisigscripthash.js
@@ -2,7 +2,7 @@
 /* jshint unused: false */
 
 require('chai').should()
-var _ = require('lodash')
+var _ = require('../../../lib/util/_')
 
 var bsv = require('../../..')
 var Transaction = bsv.Transaction

--- a/test/transaction/unspentoutput.js
+++ b/test/transaction/unspentoutput.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var _ = require('lodash')
+var _ = require('../../lib/util/_')
 var chai = require('chai')
 var expect = chai.expect
 

--- a/test/transaction/unspentoutput.js
+++ b/test/transaction/unspentoutput.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var _ = require('../../lib/util/_')
 var chai = require('chai')
 var expect = chai.expect
+var cloneDeep = require('clone-deep')
 
 var bsv = require('../..')
 var UnspentOutput = bsv.Transaction.UnspentOutput
@@ -38,7 +38,7 @@ describe('UnspentOutput', function () {
   })
 
   it('fails if vout is not a number', function () {
-    var sample = _.cloneDeep(sampleData2)
+    var sample = cloneDeep(sampleData2)
     sample.vout = '1'
     expect(function () {
       return new UnspentOutput(sample)


### PR DESCRIPTION
Replace lodash methods with inline pure javascript methods and remove lodash as a dev dependency, thus removing it completely from the project.  Related to PR #85.