### PR TITLE
Refactor bufferutil

### DIFF
--- a/lib/block/merkleblock.js
+++ b/lib/block/merkleblock.js
@@ -147,7 +147,7 @@ MerkleBlock.prototype.validMerkleTree = function validMerkleTree () {
   if (opts.hashesUsed !== this.hashes.length) {
     return false
   }
-  return BufferUtil.equals(root, this.header.merkleRoot)
+  return root.equals(this.header.merkleRoot)
 }
 
 /**

--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -1,7 +1,6 @@
 'use strict'
 
 var BN = require('./bn')
-var BufferUtil = require('../util/buffer')
 
 var EC = require('elliptic').ec
 var ec = new EC('secp256k1')
@@ -149,7 +148,7 @@ Point.pointToCompressed = function pointToCompressed (point) {
   } else {
     prefix = Buffer.from([0x02])
   }
-  return BufferUtil.concat([prefix, xbuf])
+  return Buffer.concat([prefix, xbuf])
 }
 
 /**

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -466,7 +466,7 @@ HDPrivateKey.prototype._buildFromBuffers = function (arg) {
 
   var sequence = [
     arg.version, arg.depth, arg.parentFingerPrint, arg.childIndex, arg.chainCode,
-    BufferUtil.emptyBuffer(1), arg.privateKey
+    Buffer.alloc(1), arg.privateKey
   ]
   var concat = buffer.Buffer.concat(sequence)
   if (!arg.checksum || !arg.checksum.length) {

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -371,8 +371,8 @@ HDPrivateKey.prototype._buildFromObject = function (arg) {
     depth: _.isNumber(arg.depth) ? BufferUtil.integerAsSingleByteBuffer(arg.depth) : arg.depth,
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
-    chainCode: _.isString(arg.chainCode) ? BufferUtil.hexToBuffer(arg.chainCode) : arg.chainCode,
-    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? BufferUtil.hexToBuffer(arg.privateKey) : arg.privateKey,
+    chainCode: _.isString(arg.chainCode) ? Buffer.from(arg.chainCode, 'hex') : arg.chainCode,
+    privateKey: (_.isString(arg.privateKey) && JSUtil.isHexa(arg.privateKey)) ? Buffer.from(arg.privateKey, 'hex') : arg.privateKey,
     checksum: arg.checksum ? (arg.checksum.length ? arg.checksum : BufferUtil.integerAsBuffer(arg.checksum)) : undefined
   }
   return this._buildFromBuffers(buffers)
@@ -408,7 +408,7 @@ HDPrivateKey.prototype._generateRandomly = function (network) {
 HDPrivateKey.fromSeed = function (hexa, network) {
   /* jshint maxcomplexity: 8 */
   if (JSUtil.isHexaString(hexa)) {
-    hexa = BufferUtil.hexToBuffer(hexa)
+    hexa = Buffer.from(hexa, 'hex')
   }
   if (!Buffer.isBuffer(hexa)) {
     throw new hdErrors.InvalidEntropyArgument(hexa)

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -241,14 +241,14 @@ HDPrivateKey.prototype._deriveWithNumber = function (index, hardened, nonComplia
     // The private key serialization in this case will not be exactly 32 bytes and can be
     // any value less, and the value is not zero-padded.
     var nonZeroPadded = this.privateKey.bn.toBuffer()
-    data = BufferUtil.concat([buffer.Buffer.from([0]), nonZeroPadded, indexBuffer])
+    data = Buffer.concat([buffer.Buffer.from([0]), nonZeroPadded, indexBuffer])
   } else if (hardened) {
     // This will use a 32 byte zero padded serialization of the private key
     var privateKeyBuffer = this.privateKey.bn.toBuffer({ size: 32 })
     assert(privateKeyBuffer.length === 32, 'length of private key buffer is expected to be 32 bytes')
-    data = BufferUtil.concat([buffer.Buffer.from([0]), privateKeyBuffer, indexBuffer])
+    data = Buffer.concat([buffer.Buffer.from([0]), privateKeyBuffer, indexBuffer])
   } else {
-    data = BufferUtil.concat([this.publicKey.toBuffer(), indexBuffer])
+    data = Buffer.concat([this.publicKey.toBuffer(), indexBuffer])
   }
   var hash = Hash.sha512hmac(data, this._buffers.chainCode)
   var leftPart = BN.fromBuffer(hash.slice(0, 32), {

--- a/lib/hdprivatekey.js
+++ b/lib/hdprivatekey.js
@@ -581,7 +581,7 @@ HDPrivateKey.prototype.toObject = HDPrivateKey.prototype.toJSON = function toObj
     fingerPrint: BufferUtil.integerFromBuffer(this.fingerPrint),
     parentFingerPrint: BufferUtil.integerFromBuffer(this._buffers.parentFingerPrint),
     childIndex: BufferUtil.integerFromBuffer(this._buffers.childIndex),
-    chainCode: BufferUtil.bufferToHex(this._buffers.chainCode),
+    chainCode: this._buffers.chainCode.toString('hex'),
     privateKey: this.privateKey.toBuffer().toString('hex'),
     checksum: BufferUtil.integerFromBuffer(this._buffers.checksum),
     xprivkey: this.xprivkey

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -162,7 +162,7 @@ HDPublicKey.prototype._deriveWithNumber = function (index, hardened) {
   }
 
   var indexBuffer = BufferUtil.integerAsBuffer(index)
-  var data = BufferUtil.concat([this.publicKey.toBuffer(), indexBuffer])
+  var data = Buffer.concat([this.publicKey.toBuffer(), indexBuffer])
   var hash = Hash.sha512hmac(data, this._buffers.chainCode)
   var leftPart = BN.fromBuffer(hash.slice(0, 32), { size: 32 })
   var chainCode = hash.slice(32, 64)
@@ -339,7 +339,7 @@ HDPublicKey.prototype._buildFromBuffers = function (arg) {
     arg.version, arg.depth, arg.parentFingerPrint, arg.childIndex, arg.chainCode,
     arg.publicKey
   ]
-  var concat = BufferUtil.concat(sequence)
+  var concat = Buffer.concat(sequence)
   var checksum = Base58Check.checksum(concat)
   if (!arg.checksum || !arg.checksum.length) {
     arg.checksum = checksum
@@ -351,7 +351,7 @@ HDPublicKey.prototype._buildFromBuffers = function (arg) {
   var network = Network.get(BufferUtil.integerFromBuffer(arg.version))
 
   var xpubkey
-  xpubkey = Base58Check.encode(BufferUtil.concat(sequence))
+  xpubkey = Base58Check.encode(Buffer.concat(sequence))
   arg.xpubkey = Buffer.from(xpubkey)
 
   var publicKey = new PublicKey(arg.publicKey, { network: network })

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -439,7 +439,7 @@ HDPublicKey.prototype.toObject = HDPublicKey.prototype.toJSON = function toObjec
     fingerPrint: BufferUtil.integerFromBuffer(this.fingerPrint),
     parentFingerPrint: BufferUtil.integerFromBuffer(this._buffers.parentFingerPrint),
     childIndex: BufferUtil.integerFromBuffer(this._buffers.childIndex),
-    chainCode: BufferUtil.bufferToHex(this._buffers.chainCode),
+    chainCode: this._buffers.chainCode.toString('hex'),
     publicKey: this.publicKey.toString(),
     checksum: BufferUtil.integerFromBuffer(this._buffers.checksum),
     xpubkey: this.xpubkey

--- a/lib/hdpublickey.js
+++ b/lib/hdpublickey.js
@@ -285,8 +285,8 @@ HDPublicKey.prototype._buildFromObject = function (arg) {
     depth: _.isNumber(arg.depth) ? BufferUtil.integerAsSingleByteBuffer(arg.depth) : arg.depth,
     parentFingerPrint: _.isNumber(arg.parentFingerPrint) ? BufferUtil.integerAsBuffer(arg.parentFingerPrint) : arg.parentFingerPrint,
     childIndex: _.isNumber(arg.childIndex) ? BufferUtil.integerAsBuffer(arg.childIndex) : arg.childIndex,
-    chainCode: _.isString(arg.chainCode) ? BufferUtil.hexToBuffer(arg.chainCode) : arg.chainCode,
-    publicKey: _.isString(arg.publicKey) ? BufferUtil.hexToBuffer(arg.publicKey)
+    chainCode: _.isString(arg.chainCode) ? Buffer.from(arg.chainCode, 'hex') : arg.chainCode,
+    publicKey: _.isString(arg.publicKey) ? Buffer.from(arg.publicKey, 'hex')
       : BufferUtil.isBuffer(arg.publicKey) ? arg.publicKey : arg.publicKey.toBuffer(),
     checksum: _.isNumber(arg.checksum) ? BufferUtil.integerAsBuffer(arg.checksum) : arg.checksum
   }

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -927,7 +927,7 @@ Script.buildPublicKeyIn = function (signature, sigtype) {
     signature = signature.toBuffer()
   }
   var script = new Script()
-  script.add(BufferUtil.concat([
+  script.add(Buffer.concat([
     signature,
     BufferUtil.integerAsSingleByteBuffer(sigtype || Signature.SIGHASH_ALL)
   ]))
@@ -949,7 +949,7 @@ Script.buildPublicKeyHashIn = function (publicKey, signature, sigtype) {
     signature = signature.toBuffer()
   }
   var script = new Script()
-    .add(BufferUtil.concat([
+    .add(Buffer.concat([
       signature,
       BufferUtil.integerAsSingleByteBuffer(sigtype || Signature.SIGHASH_ALL)
     ]))

--- a/lib/script/script.js
+++ b/lib/script/script.js
@@ -643,7 +643,7 @@ Script.prototype.equals = function (script) {
     if (BufferUtil.isBuffer(this.chunks[i].buf) && !BufferUtil.isBuffer(script.chunks[i].buf)) {
       return false
     }
-    if (BufferUtil.isBuffer(this.chunks[i].buf) && !BufferUtil.equals(this.chunks[i].buf, script.chunks[i].buf)) {
+    if (BufferUtil.isBuffer(this.chunks[i].buf) && !this.chunks[i].buf.equals(script.chunks[i].buf)) {
       return false
     } else if (this.chunks[i].opcodenum !== script.chunks[i].opcodenum) {
       return false

--- a/lib/transaction/input/multisig.js
+++ b/lib/transaction/input/multisig.js
@@ -107,7 +107,7 @@ MultiSigInput.prototype._createSignatures = function () {
   return _.map(
     _.filter(this.signatures, function (signature) { return !_.isUndefined(signature) }),
     function (signature) {
-      return BufferUtil.concat([
+      return Buffer.concat([
         signature.signature.toDER(),
         BufferUtil.integerAsSingleByteBuffer(signature.sigtype)
       ])

--- a/lib/transaction/input/multisigscripthash.js
+++ b/lib/transaction/input/multisigscripthash.js
@@ -108,7 +108,7 @@ MultiSigScriptHashInput.prototype._createSignatures = function () {
   return _.map(
     _.filter(this.signatures, function (signature) { return !_.isUndefined(signature) }),
     function (signature) {
-      return BufferUtil.concat([
+      return Buffer.concat([
         signature.signature.toDER(),
         BufferUtil.integerAsSingleByteBuffer(signature.sigtype)
       ])

--- a/lib/transaction/input/publickeyhash.js
+++ b/lib/transaction/input/publickeyhash.js
@@ -3,7 +3,6 @@
 var inherits = require('inherits')
 
 var $ = require('../../util/preconditions')
-var BufferUtil = require('../../util/buffer')
 
 var Hash = require('../../crypto/hash')
 var Input = require('./input')
@@ -36,7 +35,7 @@ PublicKeyHashInput.prototype.getSignatures = function (transaction, privateKey, 
   hashData = hashData || Hash.sha256ripemd160(privateKey.publicKey.toBuffer())
   sigtype = sigtype || (Signature.SIGHASH_ALL | Signature.SIGHASH_FORKID)
 
-  if (BufferUtil.equals(hashData, this.output.script.getPublicKeyHash())) {
+  if (hashData.equals(this.output.script.getPublicKeyHash())) {
     return [new TransactionSignature({
       publicKey: privateKey.publicKey,
       prevTxId: this.prevTxId,

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -11,7 +11,6 @@ var BN = require('../crypto/bn')
 var Hash = require('../crypto/hash')
 var ECDSA = require('../crypto/ecdsa')
 var $ = require('../util/preconditions')
-var BufferUtil = require('../util/buffer')
 var Interpreter = require('../script/interpreter')
 var _ = require('../util/_')
 
@@ -69,9 +68,9 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
     return ret
   }
 
-  var hashPrevouts = BufferUtil.emptyBuffer(32)
-  var hashSequence = BufferUtil.emptyBuffer(32)
-  var hashOutputs = BufferUtil.emptyBuffer(32)
+  var hashPrevouts = Buffer.alloc(32)
+  var hashSequence = Buffer.alloc(32)
+  var hashOutputs = Buffer.alloc(32)
 
   if (!(sighashType & Signature.SIGHASH_ANYONECANPAY)) {
     hashPrevouts = GetPrevoutHash(transaction)

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -1,9 +1,7 @@
 'use strict'
 
 var buffer = require('buffer')
-var assert = require('assert')
 
-var js = require('./js')
 var $ = require('./preconditions')
 
 module.exports = {
@@ -109,18 +107,6 @@ module.exports = {
       ret[i] = param[param.length - i - 1]
     }
     return ret
-  },
-
-  /**
-   * Transforms an hexa encoded string into a Buffer with binary values
-   *
-   * Shorthand for <tt>Buffer(string, 'hex')</tt>
-   *
-   * @param {string} string
-   * @return {Buffer}
-   */
-  hexToBuffer: function hexToBuffer (string) {
-    assert(js.isHexa(string))
-    return buffer.Buffer.from(string, 'hex')
   }
+
 }

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -6,19 +6,6 @@ var assert = require('assert')
 var js = require('./js')
 var $ = require('./preconditions')
 
-function equals (a, b) {
-  if (a.length !== b.length) {
-    return false
-  }
-  var length = a.length
-  for (var i = 0; i < length; i++) {
-    if (a[i] !== b[i]) {
-      return false
-    }
-  }
-  return true
-}
-
 module.exports = {
   /**
    * Fill a buffer with a value.
@@ -81,9 +68,6 @@ module.exports = {
    * Shortcut for <tt>buffer.Buffer.concat</tt>
    */
   concat: buffer.Buffer.concat,
-
-  equals: equals,
-  equal: equals,
 
   /**
    * Transforms a number from 0 to 255 into a Buffer of size 1 with that value

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -8,23 +8,6 @@ var $ = require('./preconditions')
 
 module.exports = {
   /**
-   * Fill a buffer with a value.
-   *
-   * @param {Buffer} buffer
-   * @param {number} value
-   * @return {Buffer}
-   */
-  fill: function fill (buffer, value) {
-    $.checkArgumentType(buffer, 'Buffer', 'buffer')
-    $.checkArgumentType(value, 'number', 'value')
-    var length = buffer.length
-    for (var i = 0; i < length; i++) {
-      buffer[i] = value
-    }
-    return buffer
-  },
-
-  /**
    * Return a copy of a buffer
    *
    * @param {Buffer} original

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -139,6 +139,3 @@ module.exports = {
     return buffer.Buffer.from(string, 'hex')
   }
 }
-
-module.exports.NULL_HASH = module.exports.fill(Buffer.alloc(32), 0)
-module.exports.EMPTY_BUFFER = Buffer.alloc(0)

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -31,21 +31,6 @@ module.exports = {
   },
 
   /**
-   * Returns a zero-filled byte array
-   *
-   * @param {number} bytes
-   * @return {Buffer}
-   */
-  emptyBuffer: function emptyBuffer (bytes) {
-    $.checkArgumentType(bytes, 'number', 'bytes')
-    var result = buffer.Buffer.alloc(bytes)
-    for (var i = 0; i < bytes; i++) {
-      result.write('\0', i)
-    }
-    return result
-  },
-
-  /**
    * Concatenates a buffer
    *
    * Shortcut for <tt>buffer.Buffer.concat</tt>

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -29,13 +29,6 @@ module.exports = {
   },
 
   /**
-   * Concatenates a buffer
-   *
-   * Shortcut for <tt>buffer.Buffer.concat</tt>
-   */
-  concat: buffer.Buffer.concat,
-
-  /**
    * Transforms a number from 0 to 255 into a Buffer of size 1 with that value
    *
    * @param {number} integer

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -84,19 +84,6 @@ module.exports = {
   },
 
   /**
-   * Transforms a buffer into a string with a number in hexa representation
-   *
-   * Shorthand for <tt>buffer.toString('hex')</tt>
-   *
-   * @param {Buffer} buffer
-   * @return {string}
-   */
-  bufferToHex: function bufferToHex (buffer) {
-    $.checkArgumentType(buffer, 'Buffer', 'buffer')
-    return buffer.toString('hex')
-  },
-
-  /**
    * Reverse a buffer
    * @param {Buffer} param
    * @return {Buffer}

--- a/test/script/script.js
+++ b/test/script/script.js
@@ -4,7 +4,6 @@ var should = require('chai').should()
 var expect = require('chai').expect
 var bsv = require('../..')
 
-var BufferUtil = bsv.util.buffer
 var Script = bsv.Script
 var Networks = bsv.Networks
 var Opcode = bsv.Opcode
@@ -1102,18 +1101,18 @@ describe('Script', function () {
     it('for a P2PKH address', function () {
       var address = Address.fromString('1NaTVwXDDUJaXDQajoa9MqHhz4uTxtgK14')
       var script = Script.buildPublicKeyHashOut(address)
-      expect(BufferUtil.equal(script.getData(), address.hashBuffer)).to.equal(true)
+      expect(script.getData().equals(address.hashBuffer)).to.equal(true)
     })
     it('for a P2SH address', function () {
       var address = Address.fromString('3GhtMmAbWrUf6Y8vDxn9ETB14R6V7Br3mt')
       var script = new Script(address)
-      expect(BufferUtil.equal(script.getData(), address.hashBuffer)).to.equal(true)
+      expect(script.getData().equals(address.hashBuffer)).to.equal(true)
     })
     it('for a old-style opreturn output', function () {
-      expect(BufferUtil.equal(Script('OP_RETURN 1 0xFF').getData(), Buffer.from([255]))).to.equal(true)
+      expect(Script('OP_RETURN 1 0xFF').getData().equals(Buffer.from([255]))).to.equal(true)
     })
     it('for a safe opreturn output', function () {
-      expect(BufferUtil.equal(Script('OP_FALSE OP_RETURN 1 0xFF').getData()[0], Buffer.from([255]))).to.equal(true)
+      expect(Script('OP_FALSE OP_RETURN 1 0xFF').getData()[0].equals(Buffer.from([255]))).to.equal(true)
     })
     it('fails if content is not recognized', function () {
       expect(function () {

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -69,23 +69,6 @@ describe('buffer utils', function () {
     })
   })
 
-  describe('buffer to hex', function () {
-    it('returns an expected value in hexa', function () {
-      expect(BufferUtil.bufferToHex(Buffer.from([255, 0, 128]))).to.equal('ff0080')
-    })
-    it('checks the argument type', function () {
-      expect(function () {
-        BufferUtil.bufferToHex('invalid')
-      }).to.throw(errors.InvalidArgumentType)
-    })
-    it('round trips', function () {
-      var original = Buffer.from([255, 0, 128])
-      var hexa = BufferUtil.bufferToHex(original)
-      var back = Buffer.from(hexa, 'hex')
-      expect(original.equals(back)).to.equal(true)
-    })
-  })
-
   describe('reverse', function () {
     it('reverses a buffer', function () {
       // http://bit.ly/1J2Ai4x

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -9,30 +9,6 @@ var errors = bsv.errors
 var BufferUtil = bsv.util.buffer
 
 describe('buffer utils', function () {
-  describe('equals', function () {
-    it('recognizes these two equal buffers', function () {
-      var bufferA = Buffer.from([1, 2, 3])
-      var bufferB = Buffer.from('010203', 'hex')
-      BufferUtil.equal(bufferA, bufferB).should.equal(true)
-    })
-    it('no false positive: returns false with two different buffers', function () {
-      var bufferA = Buffer.from([1, 2, 3])
-      var bufferB = Buffer.from('010204', 'hex')
-      BufferUtil.equal(bufferA, bufferB).should.equal(false)
-    })
-    it('coverage: quickly realizes a difference in size and returns false', function () {
-      var bufferA = Buffer.from([1, 2, 3])
-      var bufferB = Buffer.from([])
-      BufferUtil.equal(bufferA, bufferB).should.equal(false)
-    })
-    it('"equals" is an an alias for "equal"', function () {
-      var bufferA = Buffer.from([1, 2, 3])
-      var bufferB = Buffer.from([1, 2, 3])
-      BufferUtil.equal(bufferA, bufferB).should.equal(true)
-      BufferUtil.equals(bufferA, bufferB).should.equal(true)
-    })
-  })
-
   describe('fill', function () {
     it('checks arguments', function () {
       expect(function () {
@@ -138,7 +114,7 @@ describe('buffer utils', function () {
       var original = Buffer.from([255, 0, 128])
       var hexa = BufferUtil.bufferToHex(original)
       var back = BufferUtil.hexToBuffer(hexa)
-      expect(BufferUtil.equal(original, back)).to.equal(true)
+      expect(original.equals(back)).to.equal(true)
     })
   })
 

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -81,7 +81,7 @@ describe('buffer utils', function () {
     it('round trips', function () {
       var original = Buffer.from([255, 0, 128])
       var hexa = BufferUtil.bufferToHex(original)
-      var back = BufferUtil.hexToBuffer(hexa)
+      var back = Buffer.from(hexa, 'hex')
       expect(original.equals(back)).to.equal(true)
     })
   })

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -18,21 +18,6 @@ describe('buffer utils', function () {
     })
   })
 
-  describe('emptyBuffer', function () {
-    it('creates a buffer filled with zeros', function () {
-      var buffer = BufferUtil.emptyBuffer(10)
-      expect(buffer.length).to.equal(10)
-      for (var i = 0; i < 10; i++) {
-        expect(buffer[i]).to.equal(0)
-      }
-    })
-    it('checks arguments', function () {
-      expect(function () {
-        BufferUtil.emptyBuffer('invalid')
-      }).to.throw(errors.InvalidArgumentType)
-    })
-  })
-
   describe('single byte buffer <=> integer', function () {
     it('integerAsSingleByteBuffer should return a buffer of length 1', function () {
       expect(BufferUtil.integerAsSingleByteBuffer(100)[0]).to.equal(100)

--- a/test/util/buffer.js
+++ b/test/util/buffer.js
@@ -9,23 +9,6 @@ var errors = bsv.errors
 var BufferUtil = bsv.util.buffer
 
 describe('buffer utils', function () {
-  describe('fill', function () {
-    it('checks arguments', function () {
-      expect(function () {
-        BufferUtil.fill('something')
-      }).to.throw(errors.InvalidArgumentType)
-      expect(function () {
-        BufferUtil.fill(Buffer.from([0, 0, 0]), 'invalid')
-      }).to.throw(errors.InvalidArgumentType)
-    })
-    it('works correctly for a small buffer', function () {
-      var buffer = BufferUtil.fill(Buffer.alloc(10), 6)
-      for (var i = 0; i < 10; i++) {
-        buffer[i].should.equal(6)
-      }
-    })
-  })
-
   describe('isBuffer', function () {
     it('has no false positive', function () {
       expect(BufferUtil.isBuffer(1)).to.equal(false)


### PR DESCRIPTION
This PR removes redundant code, replacing the use of legacy utility methods with stable Node Buffer methods, which are supported in the browser via webpack and feross/buffer.