### PR TITLE
Remove buffer-compare as dependency

### DIFF
--- a/lib/transaction/transaction.js
+++ b/lib/transaction/transaction.js
@@ -3,7 +3,6 @@
 var _ = require('../util/_')
 var $ = require('../util/preconditions')
 var buffer = require('buffer')
-var compare = Buffer.compare || require('buffer-compare')
 
 var errors = require('../errors')
 var BufferUtil = require('../util/buffer')
@@ -959,7 +958,7 @@ Transaction.prototype.sort = function () {
   this.sortInputs(function (inputs) {
     var copy = Array.prototype.concat.apply([], inputs)
     copy.sort(function (first, second) {
-      return compare(first.prevTxId, second.prevTxId) ||
+      return first.prevTxId.compare(second.prevTxId) ||
         first.outputIndex - second.outputIndex
     })
     return copy
@@ -968,7 +967,7 @@ Transaction.prototype.sort = function () {
     var copy = Array.prototype.concat.apply([], outputs)
     copy.sort(function (first, second) {
       return first.satoshis - second.satoshis ||
-        compare(first.script.toBuffer(), second.script.toBuffer())
+        first.script.toBuffer().compare(second.script.toBuffer())
     })
     return copy
   })

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "aes-js": "^3.1.2",
     "bn.js": "=4.11.8",
     "bs58": "=4.0.1",
-    "buffer-compare": "=1.1.1",
     "clone-deep": "^4.0.1",
     "elliptic": "6.4.1",
     "hash.js": "^1.1.7",


### PR DESCRIPTION
Buffer.compare() was introduced in Node v0.11.13 and
lexicographically compares buffers like buffer-compare.