### PR TITLE
WIP: Experimental benchmarking of tx creation and signing

### DIFF
--- a/benchmarking/index.js
+++ b/benchmarking/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/benchmarking')

--- a/lib/benchmarking/benchmarking.js
+++ b/lib/benchmarking/benchmarking.js
@@ -1,0 +1,95 @@
+'use strict'
+
+var bsv = require('../../')
+
+var Benchmark = require('benchmark')
+
+var Transaction = bsv.Transaction
+var Random = bsv.crypto.Random
+var Script = bsv.Script
+var fromAddress = 'mszYqVnqKoQx4jcTdJXxwKAissE3Jbrrc1'
+var toAddress = 'mrU9pEmAx26HcbKVrABvgL7AwA5fjNFoDc'
+var changeAddress = 'mgBCJAsvzgT2qNNeXsoECg2uPKrUsZ76up'
+var privateKey = 'cSBnVM4xvxarwGQuAfQFwqDg9k5tErHUHzgWsEfD4zdwUasvqRVY'
+
+var Benchmarking = function Benchmarking () {
+  if (!(this instanceof Benchmarking)) {
+    return new Benchmarking()
+  }
+  return this
+}
+
+Benchmarking.asyncFlag = false
+
+Benchmarking.prototype._createUnsignedTx = function _createUnsignedTx (numInputs) {
+  let satoshis = 1e3
+  let total = satoshis * numInputs - satoshis / 2
+  let tx = new Transaction()
+  for (let i = 0; i < numInputs; i++) {
+    tx = tx.from({
+      txId: Random.getRandomBuffer(32).toString('hex'),
+      outputIndex: 0,
+      script: Script.buildPublicKeyHashOut(fromAddress).toString(),
+      satoshis: satoshis
+    })
+  }
+  tx = tx.to([{
+    address: toAddress,
+    satoshis: total
+  }])
+    .change(changeAddress)
+  return tx
+}
+
+Benchmarking.signNumInputs = function (numInputsArray) {
+  let benchmarking = new Benchmarking()
+  let suite = new Benchmark.Suite()
+  numInputsArray.forEach(n => {
+    let id = 'Sign#NumInputs' + n
+    let tx = benchmarking._createUnsignedTx(n)
+    suite.add(id, function () {
+      tx.sign(privateKey)
+    })
+  })
+  // add listeners
+  suite.on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  suite.run({ 'async': this.asyncFlag })
+}
+
+Benchmarking.createNumInputs = function (numInputsArray) {
+  let benchmarking = new Benchmarking()
+  let suite = new Benchmark.Suite()
+  numInputsArray.forEach(n => {
+    let id = 'Create#NumInputs' + n
+    suite.add(id, function () {
+      benchmarking._createUnsignedTx(n)
+    })
+  })
+  suite.on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  suite.run({ 'async': this.asyncFlag })
+}
+
+Benchmarking.createAndSignNumInputs = function (numInputsArray) {
+  let benchmarking = new Benchmarking()
+  let suite = new Benchmark.Suite()
+  numInputsArray.forEach(n => {
+    let id = 'CreateAndSign#NumInputs' + n
+    let testfn = function () {
+      let tx = benchmarking._createUnsignedTx(n)
+      tx.sign(privateKey)
+    }
+    suite.add(id, function () {
+      testfn()
+    })
+  })
+  suite.on('cycle', function (event) {
+    console.log(String(event.target))
+  })
+  suite.run({ 'async': this.asyncFlag })
+}
+
+module.exports = Benchmarking

--- a/lib/benchmarking/index.js
+++ b/lib/benchmarking/index.js
@@ -1,0 +1,4 @@
+var bsv = require('../../')
+bsv.Benchmarking = require('./benchmarking')
+
+module.exports = bsv.Benchmarking

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "standard && mocha",
     "coverage": "nyc --reporter=text npm run test",
     "build-bsv": "webpack index.js --config webpack.config.js",
+    "build-benchmarking": "webpack benchmarking/index.js --config webpack.subproject.config.js --output-library bsvBenchmarking -o bsv-benchmarking.min.js",
     "build-ecies": "webpack ecies/index.js --config webpack.subproject.config.js --output-library bsvEcies -o bsv-ecies.min.js",
     "build-message": "webpack message/index.js --config webpack.subproject.config.js --output-library bsvMessage -o bsv-message.min.js",
     "build-mnemonic": "webpack mnemonic/index.js --config webpack.subproject.config.js --output-library bsvMnemonic -o bsv-mnemonic.min.js",
@@ -50,6 +51,7 @@
     "unorm": "1.4.1"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "brfs": "2.0.1",
     "chai": "4.2.0",
     "mocha": "^5.2.0",

--- a/test-benchmarking.html
+++ b/test-benchmarking.html
@@ -1,0 +1,22 @@
+<html>
+<meta charset="utf-8" />
+
+<head>
+    <title>Benchmarking Test</title>
+</head>
+
+<body>
+    <p>Check console.log in inspector for results of benchmarking.</p>
+    <p>Note: console errors due to an issue with benchmark package,
+        <i>"Uncaught ReferenceError: define is not defined"</i></p>
+    <script src="./bsv.min.js"></script>
+    <script src="./bsv-benchmarking.min.js"></script>
+    <script type="text/javascript">
+        window.onload = function () {
+            bsv.Benchmarking.asyncFlag = true
+            bsv.Benchmarking.createAndSignNumInputs([1, 10, 20, 30])
+        }
+    </script>
+</body>
+
+</html>

--- a/test-benchmarking.js
+++ b/test-benchmarking.js
@@ -1,0 +1,29 @@
+var Benchmarking = require('./benchmarking')
+
+/*
+Sign#NumInputs1 x 204 ops/sec ±4.60% (84 runs sampled)
+Sign#NumInputs10 x 27.40 ops/sec ±0.92% (49 runs sampled)
+Sign#NumInputs20 x 13.99 ops/sec ±0.78% (39 runs sampled)
+Sign#NumInputs30 x 8.98 ops/sec ±1.33% (27 runs sampled)
+Create#NumInputs1 x 12,780 ops/sec ±2.26% (90 runs sampled)
+Create#NumInputs10 x 2,628 ops/sec ±0.49% (94 runs sampled)
+Create#NumInputs20 x 1,336 ops/sec ±0.87% (94 runs sampled)
+Create#NumInputs30 x 877 ops/sec ±0.67% (90 runs sampled)
+CreateAndSign#NumInputs1 x 212 ops/sec ±0.98% (82 runs sampled)
+CreateAndSign#NumInputs10 x 27.41 ops/sec ±0.53% (49 runs sampled)
+CreateAndSign#NumInputs20 x 13.63 ops/sec ±0.68% (38 runs sampled)
+CreateAndSign#NumInputs30 x 8.90 ops/sec ±1.30% (26 runs sampled)
+*/
+// Benchmarking.signNumInputs([1, 10, 20, 30])
+// Benchmarking.createNumInputs([1, 10, 20, 30])
+Benchmarking.createAndSignNumInputs([1, 10, 20, 30])
+
+/*
+Create#NumInputs1 x 12,796 ops/sec ±4.60% (90 runs sampled)
+Create#NumInputs10 x 2,651 ops/sec ±0.97% (93 runs sampled)
+Create#NumInputs100 x 230 ops/sec ±0.69% (83 runs sampled)
+Create#NumInputs1000 x 7.08 ops/sec ±2.94% (22 runs sampled)
+Create#NumInputs2000 x 2.06 ops/sec ±0.95% (10 runs sampled)
+Create#NumInputs3000 x 0.95 ops/sec ±1.27% (7 runs sampled)
+*/
+// Benchmarking.createNumInputs([1, 10, 100, 1000, 2000, 3000])


### PR DESCRIPTION
This is an experimental PR related to PR #120. It might be useful to develop a set of benchmarks for core bsv functions to help quantify any performance improvements and regressions, especially when dependencies are updated.  Run with `node test-benchmark.js`.

```
Sign#NumInputs1 x 204 ops/sec ±4.60% (84 runs sampled)
Sign#NumInputs10 x 27.40 ops/sec ±0.92% (49 runs sampled)
Sign#NumInputs20 x 13.99 ops/sec ±0.78% (39 runs sampled)
Sign#NumInputs30 x 8.98 ops/sec ±1.33% (27 runs sampled)
Create#NumInputs1 x 12,780 ops/sec ±2.26% (90 runs sampled)
Create#NumInputs10 x 2,628 ops/sec ±0.49% (94 runs sampled)
Create#NumInputs20 x 1,336 ops/sec ±0.87% (94 runs sampled)
Create#NumInputs30 x 877 ops/sec ±0.67% (90 runs sampled)
CreateAndSign#NumInputs1 x 212 ops/sec ±0.98% (82 runs sampled)
CreateAndSign#NumInputs10 x 27.41 ops/sec ±0.53% (49 runs sampled)
CreateAndSign#NumInputs20 x 13.63 ops/sec ±0.68% (38 runs sampled)
CreateAndSign#NumInputs30 x 8.90 ops/sec ±1.30% (26 runs sampled)
```

From this and Node profiling, the time spent creating a transaction with many inputs appears to be negligible compared to the time required for signing which is mostly spent in bn.js.