### PR TITLE
add txid helper to tx-in

### DIFF
--- a/lib/tx-in.js
+++ b/lib/tx-in.js
@@ -9,6 +9,7 @@
  */
 'use strict'
 
+import { Br } from './br'
 import { Bw } from './bw'
 import { VarInt } from './var-int'
 import { OpCode } from './op-code'
@@ -129,7 +130,10 @@ class TxIn extends Struct {
     }
     return false
   }
-
+  
+  txid () {
+    return new Br(this.txHashBuf).readReverse().toString('hex');
+  }
   /**
      * Analagous to bitcoind's SetNull in COutPoint
      */

--- a/lib/tx-in.js
+++ b/lib/tx-in.js
@@ -134,7 +134,7 @@ class TxIn extends Struct {
   txid () {
     return new Br(this.txHashBuf).readReverse().toString('hex')
   }
-  
+
   /**
      * Analagous to bitcoind's SetNull in COutPoint
      */

--- a/lib/tx-in.js
+++ b/lib/tx-in.js
@@ -130,10 +130,11 @@ class TxIn extends Struct {
     }
     return false
   }
-  
+
   txid () {
-    return new Br(this.txHashBuf).readReverse().toString('hex');
+    return new Br(this.txHashBuf).readReverse().toString('hex')
   }
+  
   /**
      * Analagous to bitcoind's SetNull in COutPoint
      */


### PR DESCRIPTION
Based on the .id() helper for `Tx`, I added a `.txid()` helper to `txIn` to access the hex of the `txIn.txHashBuf`