### PR TITLE
Add new opcode names for BitcoinSV opcodes, OP_SPLIT, etc.

### DIFF
--- a/lib/op-code.js
+++ b/lib/op-code.js
@@ -72,11 +72,14 @@ const map = {
   OP_SWAP: 0x7c,
   OP_TUCK: 0x7d,
 
-  // splice ops
+  // data manipulation ops
   OP_CAT: 0x7e,
-  OP_SUBSTR: 0x7f,
-  OP_LEFT: 0x80,
-  OP_RIGHT: 0x81,
+  OP_SUBSTR: 0x7f, // Replaced in BSV
+  OP_SPLIT: 0x7f,
+  OP_LEFT: 0x80, // Replaced in BSV
+  OP_NUM2BIN: 0x80,
+  OP_RIGHT: 0x81, // Replaced in BSV
+  OP_BIN2NUM: 0x81,
   OP_SIZE: 0x82,
 
   // bit logic

--- a/test/op-code.js
+++ b/test/op-code.js
@@ -9,14 +9,14 @@ describe('OpCode', function () {
     should.exist(opCode)
   })
 
-  it('should have 121 opCodes', function () {
+  it('should have 124 opCodes', function () {
     let i = 0
     for (const key in OpCode) {
       if (key.indexOf('OP_') !== -1) {
         i++
       }
     }
-    i.should.equal(121)
+    i.should.equal(124)
   })
 
   it('should convert to a string with this handy syntax', function () {


### PR DESCRIPTION
In May 18 of 2018 the following opcodes were re-enabled with different functionality[1]:

~~OP_SUBSTR~~ -> OP_SPLIT
~~OP_LEFT~~ -> OP_NUM2BIN
~~OP_RIGHT~~ -> OP_BIN2NUM

This PR adds the new opcode names to the opcode map. Also, closes #161 


[1] https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-reenabled-opcodes.md