### PR TITLE
fix duplicate execute script

### DIFF
--- a/lib/interp.js
+++ b/lib/interp.js
@@ -61,6 +61,7 @@ import { TxIn } from './tx-in'
     }
 
     initialize () {
+      this.script = new Script()
       this.stack = []
       this.altStack = []
       this.pc = 0

--- a/test/interp.js
+++ b/test/interp.js
@@ -199,6 +199,14 @@ describe('Interp', function () {
   })
 
   describe('#verify', function () {
+    it('should has correct stack size after verify', function () {
+      const interp = new Interp()
+      const script = Script.fromAsmString('OP_1')
+      interp.script = script
+      interp.verify()
+      should.equal(interp.stack.length, 1)
+    })
+
     it('should verify or unverify these trivial scripts from script_valid.json', function () {
       let verified
       verified = new Interp().verify(


### PR DESCRIPTION
Currently, any script will be run 2 times. Due to a bug in `interp.js`.