### PR TITLE
Fixed incorrect Regtest max bits

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -77,7 +77,7 @@ Constants.Regtest = Object.assign({}, Constants.Mainnet, {
     privKey: 0x04358394
   },
   Block: {
-    maxNBits: 0x1d00ffff,
+    maxNBits: 0x207fffff,
     magicNum: 0xdab5bffa
   },
   Msg: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bsv",
   "description": "Javascript library for Bitcoin SV (BSV).",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "author": "Yours Inc.",
   "homepage": "https://github.com/moneybutton/bsv",
   "source": "entry.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bsv",
   "description": "Javascript library for Bitcoin SV (BSV).",
-  "version": "2.0.3",
+  "version": "2.0.0",
   "author": "Yours Inc.",
   "homepage": "https://github.com/moneybutton/bsv",
   "source": "entry.js",


### PR DESCRIPTION
Regtest max bits were set to 0x1d00ffff, which is correct for mainnet, testnet and stn, but chainparams.cpp shows the correct pow limit of regtest to be: `0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`

In bits, this would be represented as: `0x207fffff` as seen here: https://github.com/bitcoin-sv/bitcoin-sv/blob/d9b12a23dbf0d2afc5f488fa077d762b302ba873/src/test/pow_tests.cpp#L83
