### PR TITLE
Bsv legacy

### DIFF
--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -139,7 +139,7 @@ var preimageForForkId = function (transaction, sighashType, inputNumber, subscri
 var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var buf = preimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
 
-  if ((sighashType & 31) === Signature.SIGHASH_SINGLE) {
+  if (buf.toString('hex') === SIGHASH_SINGLE_BUG) {
     // The SIGHASH_SINGLE bug.
     // https://bitcointalk.org/index.php?topic=260595.0
     return buf
@@ -150,7 +150,7 @@ var sighash = function sighash (transaction, sighashType, inputNumber, subscript
   return ret
 }
 
-var preimage = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+var preimage = function preimage (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var Transaction = require('./transaction')
   var Input = require('./input')
 

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -20,7 +20,7 @@ var BITS_64_ON = 'ffffffffffffffff'
 // By default, we sign with sighash_forkid
 var DEFAULT_SIGN_FLAGS = Interpreter.SCRIPT_ENABLE_SIGHASH_FORKID
 
-var sighashForForkId = function (transaction, sighashType, inputNumber, subscript, satoshisBN) {
+var preimageForForkId = function (transaction, sighashType, inputNumber, subscript, satoshisBN) {
   var input = transaction.inputs[inputNumber]
   $.checkArgument(
     satoshisBN instanceof BN,
@@ -121,10 +121,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
   // sighashType
   writer.writeUInt32LE(sighashType >>> 0)
 
-  var buf = writer.toBuffer()
-  var ret = Hash.sha256sha256(buf)
-  ret = new BufferReader(ret).readReverse()
-  return ret
+  return writer.toBuffer()
 }
 
 /**
@@ -140,6 +137,20 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
  *
  */
 var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+  var buf = preimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
+
+  if ((sighashType & 31) === Signature.SIGHASH_SINGLE) {
+    // The SIGHASH_SINGLE bug.
+    // https://bitcointalk.org/index.php?topic=260595.0
+    return buf
+  }
+
+  var ret = Hash.sha256sha256(buf)
+  ret = new BufferReader(ret).readReverse()
+  return ret
+}
+
+var preimage = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var Transaction = require('./transaction')
   var Input = require('./input')
 
@@ -163,7 +174,7 @@ var sighash = function sighash (transaction, sighashType, inputNumber, subscript
   }
 
   if ((sighashType & Signature.SIGHASH_FORKID) && (flags & Interpreter.SCRIPT_ENABLE_SIGHASH_FORKID)) {
-    return sighashForForkId(txcopy, sighashType, inputNumber, subscript, satoshisBN)
+    return preimageForForkId(txcopy, sighashType, inputNumber, subscript, satoshisBN)
   }
 
   // For no ForkId sighash, separators need to be removed.
@@ -211,13 +222,10 @@ var sighash = function sighash (transaction, sighashType, inputNumber, subscript
     txcopy.inputs = [txcopy.inputs[inputNumber]]
   }
 
-  var buf = new BufferWriter()
+  return new BufferWriter()
     .write(txcopy.toBuffer())
     .writeInt32LE(sighashType)
     .toBuffer()
-  var ret = Hash.sha256sha256(buf)
-  ret = new BufferReader(ret).readReverse()
-  return ret
 }
 
 /**
@@ -265,6 +273,7 @@ function verify (transaction, signature, publicKey, inputIndex, subscript, satos
  * @namespace Signing
  */
 module.exports = {
+  preimage: preimage,
   sighash: sighash,
   sign: sign,
   verify: verify


### PR DESCRIPTION
sighash() calculates the preimage of a transaction and then hashes the result for signing.  This PR extracts the preimage so it can be called directly.  The sighash uses this preimage and hashes it as before.