### PR TITLE
Create empty sigoperations list

### DIFF
--- a/lib/sig-operations.js
+++ b/lib/sig-operations.js
@@ -113,7 +113,7 @@ class SigOperations extends Struct {
    */
   get (txHashBuf, txOutNum) {
     const label = txHashBuf.toString('hex') + ':' + txOutNum
-    return this.map.get(label)
+    return this.map.get(label) || []
   }
 }
 

--- a/lib/tx-builder.js
+++ b/lib/tx-builder.js
@@ -177,6 +177,7 @@ class TxBuilder extends Struct {
     this.txIns.push(
       TxIn.fromProperties(txHashBuf, txOutNum, script, nSequence)
     )
+    this.sigOperations.setMany(txHashBuf, txOutNum, [])
     this.uTxOutMap.set(txHashBuf, txOutNum, txOut)
     return this
   }

--- a/lib/tx-builder.js
+++ b/lib/tx-builder.js
@@ -177,7 +177,6 @@ class TxBuilder extends Struct {
     this.txIns.push(
       TxIn.fromProperties(txHashBuf, txOutNum, script, nSequence)
     )
-    this.sigOperations.setMany(txHashBuf, txOutNum, [])
     this.uTxOutMap.set(txHashBuf, txOutNum, txOut)
     return this
   }

--- a/test/sig-operations.js
+++ b/test/sig-operations.js
@@ -138,5 +138,12 @@ describe('SigOperations', function () {
       obj.nScriptChunk.should.equal(nScriptChunk2)
       obj.addressStr.should.equal(addressStr2.toString())
     })
+
+    it('should return empty list when no sig operation was registered', function () {
+      const sigOperations = new SigOperations()
+      const txHashBuf = Buffer.alloc(32).fill(1)
+      const result = sigOperations.get(txHashBuf, 0)
+      should(result).be.eql([])
+    })
   })
 })

--- a/test/tx-builder.js
+++ b/test/tx-builder.js
@@ -876,6 +876,38 @@ describe('TxBuilder', function () {
       TxVerifier.verify(txb.tx, txb.uTxOutMap).should.equal(true)
     })
 
+    it('should work with custom scripts', () => {
+      // make change address
+      const privKey = new PrivKey().fromBn(new Bn(100))
+      const keyPair = new KeyPair().fromPrivKey(privKey)
+      const changeaddr = new Address().fromPubKey(keyPair.pubKey)
+
+      // make addresses to send from (and to)
+      const privKey1 = new PrivKey().fromBn(new Bn(1))
+      const keyPair1 = new KeyPair().fromPrivKey(privKey1)
+      const addr1 = new Address().fromPubKey(keyPair1.pubKey)
+
+      const customScript = new Script().fromString('OP_DUP OP_HASH160 20 0x' + addr1.hashBuf.toString('hex') + ' OP_EQUALVERIFY OP_CHECKSIG')
+      
+      const txOut1 = TxOut.fromProperties(new Bn(1e8), customScript)
+      
+      const txHashBuf = Buffer.alloc(32)
+      txHashBuf.fill(1)
+      
+
+      const txb = new TxBuilder()
+      txb.setFeePerKbNum(0.0001e8)
+      txb.setChangeAddress(changeaddr)
+      txb.inputFromScript(
+        txHashBuf, 
+        0, 
+        txOut1, 
+        customScript
+      )
+      txb.build()
+      should(() => txb.signWithKeyPairs([keyPair1])).not.throw()
+    })
+
     it('should sign and verify a lot of inputs and outputs', function () {
       // make change address
       const privKey = new PrivKey().fromBn(new Bn(100))


### PR DESCRIPTION
Not returning the right default value was causing issues with custom scripts in inputs. This fix solves the issue, and scopes the changes to the sig operations class.