### PR TITLE
Check for truthy rather than null

### DIFF
--- a/lib/ecies.js
+++ b/lib/ecies.js
@@ -29,12 +29,12 @@ Ecies.ivkEkM = function (privKey, pubKey) {
   }
 }
 
-Ecies.electrumEncrypt = function (messageBuf, toPubKey, fromKeyPair, noKey = false) {
+Ecies.electrumEncrypt = function (messageBuf, toPubKey, fromKeyPair = null, noKey = false) {
   if (!Buffer.isBuffer(messageBuf)) {
     throw new Error('messageBuf must be a buffer')
   }
   let Rbuf
-  if (fromKeyPair === null) {
+  if (!fromKeyPair) {
     fromKeyPair = KeyPair.fromRandom()
   }
   if (!noKey) {
@@ -64,7 +64,7 @@ Ecies.electrumDecrypt = function (encBuf, toPrivKey, fromPubKey = null) {
     throw new Error('Invalid Magic')
   }
   let offset = 4
-  if (fromPubKey === null) {
+  if (!fromPubKey) {
     // BIE1 use compressed public key, length is always 33.
     const pub = encBuf.slice(4, 37)
     fromPubKey = PubKey.fromDer(pub)


### PR DESCRIPTION
Looking at the code, it does not seem that there is any need to specifically check for "null" since "undefined" errors out as well.  I'm proposing a more general falsy check to allow this param to be dropped all together rather than explicitly requiring "null" be passed in.