### PR TITLE
Sighash Preimage

### DIFF
--- a/lib/tx.js
+++ b/lib/tx.js
@@ -134,7 +134,7 @@ class Tx extends Struct {
     }
     return Hash.sha256Sha256(bw.toBuffer())
   }
-  
+
   /**
    * For a normal transaction, subScript is usually the scriptPubKey. For a
    * p2sh transaction, subScript is usually the redeemScript. If you're not
@@ -274,7 +274,7 @@ class Tx extends Struct {
       .write(txcopy.toBuffer())
       .writeInt32LE(nHashType)
       .toBuffer()
-    return buf;
+    return buf
   }
 
   async asyncSighashPreimage (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = {}) {

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -134,13 +134,30 @@ class Tx extends Struct {
     }
     return Hash.sha256Sha256(bw.toBuffer())
   }
-
+  
   /**
    * For a normal transaction, subScript is usually the scriptPubKey. For a
    * p2sh transaction, subScript is usually the redeemScript. If you're not
    * normal because you're using OP_CODESEPARATORs, you know what to do.
    */
   sighash (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = new HashCache()) {
+    const buf = this.sighashPreimage(nHashType, nIn, subScript, valueBn, flags, hashCache);
+    return new Br(Hash.sha256Sha256(buf)).readReverse()
+  }
+
+  async asyncSighash (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = {}) {
+    const workersResult = await Workers.asyncObjectMethod(this, 'sighash', [
+      nHashType,
+      nIn,
+      subScript,
+      valueBn,
+      flags,
+      hashCache
+    ])
+    return workersResult.resbuf
+  }
+
+  sighashPreimage (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = new HashCache()) {
     // start with UAHF part (Bitcoin SV)
     // https://github.com/Bitcoin-UAHF/spec/blob/master/replay-protected-sighash.md
     if (
@@ -257,11 +274,11 @@ class Tx extends Struct {
       .write(txcopy.toBuffer())
       .writeInt32LE(nHashType)
       .toBuffer()
-    return new Br(Hash.sha256Sha256(buf)).readReverse()
+    return buf;
   }
 
-  async asyncSighash (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = {}) {
-    const workersResult = await Workers.asyncObjectMethod(this, 'sighash', [
+  async asyncSighashPreimage (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = {}) {
+    const workersResult = await Workers.asyncObjectMethod(this, 'sighashPreimage', [
       nHashType,
       nIn,
       subScript,

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -206,7 +206,7 @@ class Tx extends Struct {
       bw.writeUInt32LE(this.nLockTime)
       bw.writeUInt32LE(nHashType >>> 0)
 
-      return new Br(Hash.sha256Sha256(bw.toBuffer())).readReverse()
+      return bw.toBuffer();
     }
 
     // original bitcoin code follows - not related to UAHF (Bitcoin SV)

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -141,7 +141,7 @@ class Tx extends Struct {
    * normal because you're using OP_CODESEPARATORs, you know what to do.
    */
   sighash (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = new HashCache()) {
-    const buf = this.sighashPreimage(nHashType, nIn, subScript, valueBn, flags, hashCache);
+    const buf = this.sighashPreimage(nHashType, nIn, subScript, valueBn, flags, hashCache)
     return new Br(Hash.sha256Sha256(buf)).readReverse()
   }
 
@@ -206,7 +206,7 @@ class Tx extends Struct {
       bw.writeUInt32LE(this.nLockTime)
       bw.writeUInt32LE(nHashType >>> 0)
 
-      return bw.toBuffer();
+      return bw.toBuffer()
     }
 
     // original bitcoin code follows - not related to UAHF (Bitcoin SV)

--- a/lib/tx.js
+++ b/lib/tx.js
@@ -142,6 +142,9 @@ class Tx extends Struct {
    */
   sighash (nHashType, nIn, subScript, valueBn, flags = 0, hashCache = new HashCache()) {
     const buf = this.sighashPreimage(nHashType, nIn, subScript, valueBn, flags, hashCache)
+    if (buf.compare(Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex')) === 0) {
+      return buf
+    }
     return new Br(Hash.sha256Sha256(buf)).readReverse()
   }
 


### PR DESCRIPTION
This abstracts out the creation of the sighash buffer from the actual hashing itself to allow access for OP_PUSH_TX transactions.