### PR TITLE
Add sighashPreimage function to Transaction

### DIFF
--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -230,6 +230,7 @@ var sighashPreimageForForkId = function (transaction, sighashType, inputNumber, 
  */
 var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var preimage = sighashPreimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
+  if(preimage.compare(SIGHASH_SINGLE_BUG) === 0) return preimage;
   var ret = Hash.sha256sha256(preimage)
   ret = new BufferReader(ret).readReverse()
   return ret

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -128,7 +128,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
 }
 
 /**
- * Returns a buffer of length 32 bytes with the hash that needs to be signed
+ * Returns a buffer with the which is hashed with sighash that needs to be signed
  * for OP_CHECKSIG.
  *
  * @name Signing.sighash
@@ -139,7 +139,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
  * @param {satoshisBN} input's amount (for  ForkId signatures)
  *
  */
-var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+ var sighashPreimage = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var Transaction = require('./transaction')
   var Input = require('./input')
 
@@ -216,7 +216,24 @@ var sighash = function sighash (transaction, sighashType, inputNumber, subscript
     .writeInt32LE(sighashType)
     .toBuffer()
   var ret = Hash.sha256sha256(buf)
-  ret = new BufferReader(ret).readReverse()
+  return ret
+}
+
+/**
+ * Returns a buffer of length 32 bytes with the hash that needs to be signed
+ * for OP_CHECKSIG.
+ *
+ * @name Signing.sighash
+ * @param {Transaction} transaction the transaction to sign
+ * @param {number} sighashType the type of the hash
+ * @param {number} inputNumber the input index for the signature
+ * @param {Script} subscript the script that will be signed
+ * @param {satoshisBN} input's amount (for  ForkId signatures)
+ *
+ */
+var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+  var preimage = sighashPreimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
+  ret = new BufferReader(preimage).readReverse()
   return ret
 }
 

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -139,7 +139,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
  * @param {satoshisBN} input's amount (for  ForkId signatures)
  *
  */
- var sighashPreimage = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+ var sighashPreimage = function sighashPreimage (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var Transaction = require('./transaction')
   var Input = require('./input')
 
@@ -282,6 +282,7 @@ function verify (transaction, signature, publicKey, inputIndex, subscript, satos
  * @namespace Signing
  */
 module.exports = {
+  sighashPreimage: sighashPreimage,
   sighash: sighash,
   sign: sign,
   verify: verify

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -14,7 +14,7 @@ var $ = require('../util/preconditions')
 var Interpreter = require('../script/interpreter')
 var _ = require('../util/_')
 
-var SIGHASH_SINGLE_BUG = '0000000000000000000000000000000000000000000000000000000000000001'
+var SIGHASH_SINGLE_BUG = Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex')
 var BITS_64_ON = 'ffffffffffffffff'
 
 // By default, we sign with sighash_forkid
@@ -137,7 +137,7 @@ var sighashPreimageForForkId = function (transaction, sighashType, inputNumber, 
  * @param {satoshisBN} input's amount (for  ForkId signatures)
  *
  */
- var sighashPreimage = function sighashPreimage (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
+var sighashPreimage = function sighashPreimage (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var Transaction = require('./transaction')
   var Input = require('./input')
 
@@ -192,7 +192,7 @@ var sighashPreimageForForkId = function (transaction, sighashType, inputNumber, 
     // The SIGHASH_SINGLE bug.
     // https://bitcointalk.org/index.php?topic=260595.0
     if (inputNumber >= txcopy.outputs.length) {
-      return Buffer.from(SIGHASH_SINGLE_BUG, 'hex')
+      return SIGHASH_SINGLE_BUG
     }
 
     txcopy.outputs.length = inputNumber + 1
@@ -230,7 +230,7 @@ var sighashPreimageForForkId = function (transaction, sighashType, inputNumber, 
  */
 var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var preimage = sighashPreimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
-  if(preimage.compare(SIGHASH_SINGLE_BUG) === 0) return preimage;
+  if (preimage.compare(SIGHASH_SINGLE_BUG) === 0) return preimage
   var ret = Hash.sha256sha256(preimage)
   ret = new BufferReader(ret).readReverse()
   return ret

--- a/lib/transaction/sighash.js
+++ b/lib/transaction/sighash.js
@@ -20,7 +20,7 @@ var BITS_64_ON = 'ffffffffffffffff'
 // By default, we sign with sighash_forkid
 var DEFAULT_SIGN_FLAGS = Interpreter.SCRIPT_ENABLE_SIGHASH_FORKID
 
-var sighashForForkId = function (transaction, sighashType, inputNumber, subscript, satoshisBN) {
+var sighashPreimageForForkId = function (transaction, sighashType, inputNumber, subscript, satoshisBN) {
   var input = transaction.inputs[inputNumber]
   $.checkArgument(
     satoshisBN instanceof BN,
@@ -122,9 +122,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
   writer.writeUInt32LE(sighashType >>> 0)
 
   var buf = writer.toBuffer()
-  var ret = Hash.sha256sha256(buf)
-  ret = new BufferReader(ret).readReverse()
-  return ret
+  return buf
 }
 
 /**
@@ -163,7 +161,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
   }
 
   if ((sighashType & Signature.SIGHASH_FORKID) && (flags & Interpreter.SCRIPT_ENABLE_SIGHASH_FORKID)) {
-    return sighashForForkId(txcopy, sighashType, inputNumber, subscript, satoshisBN)
+    return sighashPreimageForForkId(txcopy, sighashType, inputNumber, subscript, satoshisBN)
   }
 
   // For no ForkId sighash, separators need to be removed.
@@ -215,8 +213,7 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
     .write(txcopy.toBuffer())
     .writeInt32LE(sighashType)
     .toBuffer()
-  var ret = Hash.sha256sha256(buf)
-  return ret
+  return buf
 }
 
 /**
@@ -233,7 +230,8 @@ var sighashForForkId = function (transaction, sighashType, inputNumber, subscrip
  */
 var sighash = function sighash (transaction, sighashType, inputNumber, subscript, satoshisBN, flags) {
   var preimage = sighashPreimage(transaction, sighashType, inputNumber, subscript, satoshisBN, flags)
-  ret = new BufferReader(preimage).readReverse()
+  var ret = Hash.sha256sha256(preimage)
+  ret = new BufferReader(ret).readReverse()
   return ret
 }
 


### PR DESCRIPTION
From @shruggr :

This abstracts out the creation of the sighash buffer from the actual hashing itself to allow access for OP_PUSH_TX transactions.