### PR TITLE
Fix isOpReturn

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -531,13 +531,7 @@ class Script extends Struct {
   }
 
   isOpReturn () {
-    if (
-      this.chunks[0].opCodeNum === OpCode.OP_RETURN
-    ) {
-      return true
-    } else {
-      return false
-    }
+    return this.chunks[0].opCodeNum === OpCode.OP_RETURN
   }
 
   isSafeDataOut () {

--- a/lib/script.js
+++ b/lib/script.js
@@ -532,8 +532,7 @@ class Script extends Struct {
 
   isOpReturn () {
     if (
-      this.chunks[0].opCodeNum === OpCode.OP_RETURN &&
-        this.chunks.filter(chunk => Buffer.isBuffer(chunk.buf)).length === this.chunks.slice(1).length
+      this.chunks[0].opCodeNum === OpCode.OP_RETURN
     ) {
       return true
     } else {

--- a/lib/script.js
+++ b/lib/script.js
@@ -531,7 +531,8 @@ class Script extends Struct {
   }
 
   isOpReturn () {
-    return this.chunks[0].opCodeNum === OpCode.OP_RETURN
+    return !!(this.chunks[0] &&
+      this.chunks[0].opCodeNum === OpCode.OP_RETURN)
   }
 
   isSafeDataOut () {

--- a/test/script.js
+++ b/test/script.js
@@ -1202,6 +1202,16 @@ describe('Script', function () {
       const script = Script.fromAsmString('OP_RETURN 0')
       should(script.isOpReturn()).be.true()
     })
+
+    it('returns false for empty script', () => {
+      const script = new Script()
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false for only push data script', () => {
+      const script = new Script().writeBuffer(Buffer.from("I'm a lonely buffer"))
+      should(script.isOpReturn()).be.false()
+    })
   })
 
   describe('vectors', function () {

--- a/test/script.js
+++ b/test/script.js
@@ -1150,6 +1150,55 @@ describe('Script', function () {
     })
   })
 
+  describe('#isOpReturn', () => {
+    it('returns true if the script its only an OP_RETURN opcode', () => {
+      const script = new Script().writeOpCode(OpCode.OP_RETURN)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns false if the script starts with an opcode that is not OP_RETURN', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_ADD)
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false if the script starts with a push data', () => {
+      const script = new Script()
+        .writeBuffer(Buffer.from("I'm a buffer"))
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false if the script starts with "OP_FALSE OP_RETURN"', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by an OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from("I'm a buffer"))
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from("I'm a buffer"))
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+  })
+
   describe('vectors', function () {
     scriptValid.forEach(function (a, i) {
       if (a.length === 1) {

--- a/test/script.js
+++ b/test/script.js
@@ -1197,6 +1197,11 @@ describe('Script', function () {
         .writeOpCode(OpCode.OP_FALSE)
       should(script.isOpReturn()).be.true()
     })
+
+    it('returns true if the script starts OP_RETURN and then has a 0 push data', () => {
+      const script = Script.fromAsmString('OP_RETURN 0')
+      should(script.isOpReturn()).be.true()
+    })
   })
 
   describe('vectors', function () {


### PR DESCRIPTION
The method `Script#isOpReturn` had a really unexpected behavior:
``` js
Script.fromAsmString('OP_RETURN 00').isOpReturn() === false
```

The reason why this fails is because the method was checking that everything after the OP_RETURN is only push data, which is something that is not actually needed.

This PR change that behavior by just checking if the first element is an OP_RETURN opcode.

