### PR TITLE
Check for non spendable

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -530,6 +530,12 @@ class Script extends Struct {
     return true
   }
 
+  isNonSpendable () {
+    const startsWithOpFalse = this.chunks[0].opCodeNum === OpCode.OP_FALSE
+    const andThenReturns = this.chunks[1] && this.chunks[1].opCodeNum === OpCode.OP_RETURN
+    return !!startsWithOpFalse && !!andThenReturns
+  }
+
   isOpReturn () {
     if (
       this.chunks[0].opCodeNum === OpCode.OP_RETURN &&

--- a/lib/script.js
+++ b/lib/script.js
@@ -531,8 +531,14 @@ class Script extends Struct {
   }
 
   isOpReturn () {
-    return !!(this.chunks[0] &&
-      this.chunks[0].opCodeNum === OpCode.OP_RETURN)
+    if (
+      this.chunks[0].opCodeNum === OpCode.OP_RETURN &&
+        this.chunks.filter(chunk => Buffer.isBuffer(chunk.buf)).length === this.chunks.slice(1).length
+    ) {
+      return true
+    } else {
+      return false
+    }
   }
 
   isSafeDataOut () {

--- a/lib/script.js
+++ b/lib/script.js
@@ -531,13 +531,7 @@ class Script extends Struct {
   }
 
   isOpReturn () {
-    if (
-      this.chunks[0].opCodeNum === OpCode.OP_RETURN
-    ) {
-      return true
-    } else {
-      return false
-    }
+    return this.chunks[0].opCodeNum === OpCode.OP_RETURN
   }
 
   isSafeDataOut () {

--- a/lib/script.js
+++ b/lib/script.js
@@ -532,8 +532,7 @@ class Script extends Struct {
 
   isOpReturn () {
     if (
-      this.chunks[0].opCodeNum === OpCode.OP_RETURN &&
-        this.chunks.filter(chunk => Buffer.isBuffer(chunk.buf)).length === this.chunks.slice(1).length
+      this.chunks[0].opCodeNum === OpCode.OP_RETURN
     ) {
       return true
     } else {

--- a/lib/script.js
+++ b/lib/script.js
@@ -531,7 +531,8 @@ class Script extends Struct {
   }
 
   isOpReturn () {
-    return this.chunks[0].opCodeNum === OpCode.OP_RETURN
+    return !!(this.chunks[0] &&
+      this.chunks[0].opCodeNum === OpCode.OP_RETURN)
   }
 
   isSafeDataOut () {

--- a/lib/tx-builder.js
+++ b/lib/tx-builder.js
@@ -239,7 +239,7 @@ class TxBuilder extends Struct {
   buildOutputs () {
     let outAmountBn = new Bn(0)
     this.txOuts.forEach(txOut => {
-      if (txOut.valueBn.lt(this.dust) && !txOut.script.isOpReturn() && !txOut.script.isSafeDataOut()) {
+      if (txOut.valueBn.lt(this.dust) && !txOut.script.isNonSpendable()) {
         throw new Error('cannot create output lesser than dust')
       }
       outAmountBn = outAmountBn.add(txOut.valueBn)

--- a/test/script.js
+++ b/test/script.js
@@ -1202,6 +1202,16 @@ describe('Script', function () {
       const script = Script.fromAsmString('OP_RETURN 0')
       should(script.isOpReturn()).be.true()
     })
+
+    it('returns false for empty script', () => {
+      const script = new Script()
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false for only push data script', () => {
+      const script = new Script().writeBuffer(Buffer.from("I'm a lonely buffer"))
+      should(script.isOpReturn()).be.false()
+    })
   })
 
   describe('vectors', function () {

--- a/test/script.js
+++ b/test/script.js
@@ -1150,6 +1150,55 @@ describe('Script', function () {
     })
   })
 
+  describe('#isOpReturn', () => {
+    it('returns true if the script its only an OP_RETURN opcode', () => {
+      const script = new Script().writeOpCode(OpCode.OP_RETURN)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns false if the script starts with an opcode that is not OP_RETURN', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_ADD)
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false if the script starts with a push data', () => {
+      const script = new Script()
+        .writeBuffer(Buffer.from("I'm a buffer"))
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false if the script starts with "OP_FALSE OP_RETURN"', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by an OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from("I'm a buffer"))
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+
+    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from("I'm a buffer"))
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.true()
+    })
+  })
+
   describe('vectors', function () {
     scriptValid.forEach(function (a, i) {
       if (a.length === 1) {

--- a/test/script.js
+++ b/test/script.js
@@ -1206,7 +1206,7 @@ describe('Script', function () {
     })
   })
 
-  describe.only('#isNonSpendable', () => {
+  describe('#isNonSpendable', () => {
     it('returns false when OP_TRUE only', () => {
       const script = new Script().writeOpCode(OpCode.OP_TRUE)
       should(script.isNonSpendable()).be.false()

--- a/test/script.js
+++ b/test/script.js
@@ -1175,42 +1175,108 @@ describe('Script', function () {
       should(script.isOpReturn()).be.false()
     })
 
-    it('returns true if the script starts OP_RETURN and is followed by an OP_FALSE', () => {
+    it('returns false if the script starts OP_RETURN and is followed by an OP_FALSE', () => {
       const script = new Script()
         .writeOpCode(OpCode.OP_RETURN)
         .writeOpCode(OpCode.OP_FALSE)
-      should(script.isOpReturn()).be.true()
-    })
-
-    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
-      const script = new Script()
-        .writeOpCode(OpCode.OP_RETURN)
-        .writeBuffer(Buffer.from("I'm a buffer"))
-        .writeOpCode(OpCode.OP_FALSE)
-      should(script.isOpReturn()).be.true()
-    })
-
-    it('returns true if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
-      const script = new Script()
-        .writeOpCode(OpCode.OP_RETURN)
-        .writeBuffer(Buffer.from("I'm a buffer"))
-        .writeOpCode(OpCode.OP_FALSE)
-      should(script.isOpReturn()).be.true()
-    })
-
-    it('returns true if the script starts OP_RETURN and then has a 0 push data', () => {
-      const script = Script.fromAsmString('OP_RETURN 0')
-      should(script.isOpReturn()).be.true()
-    })
-
-    it('returns false for empty script', () => {
-      const script = new Script()
       should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false if the script starts OP_RETURN and is followed by data and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from("I'm a buffer"))
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('returns false for the asm script "OP_RETURN 0"', () => {
+      const script = Script.fromAsmString('OP_RETURN 0')
+      should(script.isOpReturn()).be.false()
+    })
+
+    it('throws for empty script', () => {
+      const script = new Script()
+      should(() => script.isOpReturn()).throw()
     })
 
     it('returns false for only push data script', () => {
       const script = new Script().writeBuffer(Buffer.from("I'm a lonely buffer"))
       should(script.isOpReturn()).be.false()
+    })
+  })
+
+  describe.only('#isNonSpendable', () => {
+    it('returns false when OP_TRUE only', () => {
+      const script = new Script().writeOpCode(OpCode.OP_TRUE)
+      should(script.isNonSpendable()).be.false()
+    })
+
+    it('returns true when "OP_FALSE OP_RETURN"', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+      should(script.isNonSpendable()).be.true()
+    })
+
+    it('returns false when starts with OP_FALSE but is followed by opcode that is not OP_RETURN', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_ADD)
+      should(script.isNonSpendable()).be.false()
+    })
+
+    it('returns false when is only OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+      should(script.isNonSpendable()).be.false()
+    })
+
+    it('returns true when is OP_FALSE OP_RETURN and then data', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from('some'))
+        .writeBuffer(Buffer.from('data'))
+
+      should(script.isNonSpendable()).be.true()
+    })
+
+    it('returns true when is OP_FALSE OP_RETURN and then data plus opcodes', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeBuffer(Buffer.from('some'))
+        .writeBuffer(Buffer.from('data'))
+        .writeOpCode(OpCode.OP_ADD)
+        .writeBuffer(Buffer.from('more data'))
+
+      should(script.isNonSpendable()).be.true()
+    })
+
+    it('returns true when is OP_FALSE OP_RETURN and then opcodes', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeOpCode(OpCode.OP_ADD)
+        .writeOpCode(OpCode.OP_MUL)
+
+      should(script.isNonSpendable()).be.true()
+    })
+
+    it('returns true when is OP_FALSE OP_RETURN and then OP_FALSE', () => {
+      const script = new Script()
+        .writeOpCode(OpCode.OP_FALSE)
+        .writeOpCode(OpCode.OP_RETURN)
+        .writeOpCode(OpCode.OP_FALSE)
+
+      should(script.isNonSpendable()).be.true()
+    })
+
+    it('returns true when for asm script "OP_FALSE OP_RETURN 0"', () => {
+      const script = new Script().fromAsmString('OP_FALSE OP_RETURN 0')
+
+      should(script.isNonSpendable()).be.true()
     })
   })
 

--- a/test/script.js
+++ b/test/script.js
@@ -1197,6 +1197,11 @@ describe('Script', function () {
         .writeOpCode(OpCode.OP_FALSE)
       should(script.isOpReturn()).be.true()
     })
+
+    it('returns true if the script starts OP_RETURN and then has a 0 push data', () => {
+      const script = Script.fromAsmString('OP_RETURN 0')
+      should(script.isOpReturn()).be.true()
+    })
   })
 
   describe('vectors', function () {


### PR DESCRIPTION
This PR fixes the bug where the tx builder cannot build transactions that sends 0 sats to non spendable outputs that include `OP_FALSE` after the `OP_RETURN`.

The first approach to solve this was changing the method `Script#isOpReturn` to stop checking if every chunk if the script after the OP_RETURN is push data. That is still some desirable change for the future, but some members of the community pointed out that changing that method changes behavior in a few other methods.

To avoid breaking changes, then, I created this alternative solution. Instead of changing an existing method I created a new one and modified txBuilder to use this new method.

I also added new tests for `Script#isOpReturn` to have the behavior well explained in the code.

Lastly there is are some tests for the new code and the new cases contemplated.