### PR TITLE
Limit range of privkeys from arbitrary buffers

### DIFF
--- a/lib/priv-key.js
+++ b/lib/priv-key.js
@@ -87,7 +87,13 @@ class PrivKey extends Struct {
       throw new Error('Invalid versionByteNum byte')
     }
 
-    return this.fromBn(new Bn().fromBuffer(buf.slice(1, 1 + 32)))
+    const bn = new Bn().fromBuffer(buf.slice(1, 1 + 32))
+
+    if (!this.bn.lt(Point.getN())) {
+      throw new Error('Number must be less than N')
+    }
+
+    return this.fromBn(bn)
   }
 
   toBn () {

--- a/lib/priv-key.js
+++ b/lib/priv-key.js
@@ -89,7 +89,7 @@ class PrivKey extends Struct {
 
     const bn = new Bn().fromBuffer(buf.slice(1, 1 + 32))
 
-    if (!this.bn.lt(Point.getN())) {
+    if (!bn.lt(Point.getN())) {
       throw new Error('Number must be less than N')
     }
 


### PR DESCRIPTION
The fromBuffer method assumes that the specified buffer always results
in a valid big number, smaller than the order of the curve, but this is not
always the case with an arbitrary 32-byte array.

Essentially the fromBuffer method allows reconstructing privkeys that
don't pass the validate() check.

This is important to prevent people from creating invalid privkeys.