### PR TITLE
bug fix: stack evaluation returns wrong result

### DIFF
--- a/lib/script/interpreter.js
+++ b/lib/script/interpreter.js
@@ -176,7 +176,7 @@ Interpreter.prototype.verify = function (scriptSig, scriptPubkey, tx, nin, flags
       throw new Error('internal error - CLEANSTACK without P2SH')
     }
 
-    if (stackCopy.length !== 1) {
+    if (this.stack.length !== 1) {
       this.errstr = 'SCRIPT_ERR_CLEANSTACK'
       return false
     }


### PR DESCRIPTION
To reproduce the bug, use:

> Unlocking script: OP_1
> Locking script: OP_1 OP_RETURN

Enable `Interp.SCRIPT_VERIFY_P2SH | Interp.SCRIPT_VERIFY_CLEANSTACK`.

Seen: Currently script evaluation returns true, since `stackCopy` is stack with one element 1. 

Expected: When `OP_RETURN` finishes, there are two elements on stack, both 1's. Should return false instead.